### PR TITLE
remove additional new line before and after each $$TeX$$ in LATEX file

### DIFF
--- a/latexlib.php
+++ b/latexlib.php
@@ -221,7 +221,8 @@ function offlinequiz_convert_html_to_latex($text) {
             '#' => '\#',
             '%' => '\%',
     		'&gt;' => '>',
-    		'&lt;' => '<'
+    		'&lt;' => '<',
+            '$$' => '$'
     );
     // Remove all HTML comments (typically from MS Office).
     $text = preg_replace("/<!--.*?--\s*>/ms", "", $text);


### PR DESCRIPTION
More info in issue #19 

This is a quick fix for LATEX file format.
