### PR TITLE
fix for latex misalignment in pdf files(with global and local setting)

### DIFF
--- a/backup/moodle2/backup_offlinequiz_stepslib.php
+++ b/backup/moodle2/backup_offlinequiz_stepslib.php
@@ -42,7 +42,8 @@ class backup_offlinequiz_activity_structure_step extends backup_questions_activi
                 'timeclose', 'time', 'grade', 'numgroups', 'decimalpoints',
                 'review', 'questionsperpage', 'docscreated', 'shufflequestions', 'shuffleanswers',
                 'questions', 'sumgrades', 'papergray', 'fontsize', 'timecreated',
-                'timemodified', 'fileformat', 'showgrades', 'showquestioninfo', 'showtutorial', 'printstudycodefield', 'id_digits'));
+                'timemodified', 'fileformat', 'showgrades', 'showquestioninfo', 'disableimgnewlines', 'showtutorial',
+                'printstudycodefield', 'id_digits'));
 
         $qinstances = new backup_nested_element('question_instances');
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/offlinequiz/db" VERSION="20170310" COMMENT="XMLDB file for Moodle 2.0+ mod/offlinequiz"
+<XMLDB PATH="mod/offlinequiz/db" VERSION="20171130" COMMENT="XMLDB file for Moodle 2.0+ mod/offlinequiz"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -33,6 +33,7 @@
         <FIELD NAME="showgrades" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="showtutorial" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="id_digits" TYPE="int" LENGTH="4" NOTNULL="false" SEQUENCE="false" COMMENT="Amount of digits used by offlinequiz-instance to match idnumbers"/>
+        <FIELD NAME="disableimgnewlines" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Enable or disable new lines around images"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for offlinequiz"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1370,6 +1370,21 @@ function xmldb_offlinequiz_upgrade($oldversion = 0) {
     		$dbman->add_index($table, $index);
 		}
     }
+
+    if ($oldversion < 2017113001) {
+
+        // Define field disableimgnewlines to be added to offlinequiz.
+        $table = new xmldb_table('offlinequiz');
+        $field = new xmldb_field('disableimgnewlines', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, '0', 'id_digits');
+
+        // Conditionally launch add field disableimgnewlines.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Offlinequiz savepoint reached.
+        upgrade_mod_savepoint(true, 2017113001, 'offlinequiz');
+    }
     // TODO migrate old offlinequiz_q_instances maxmarks to new maxmark field in offlinequiz_group_questions.
     // TODO migrate  offlinequiz_group_questions to fill in page field correctly. For every group use the
     //      position field to find new pages and insert them.

--- a/docxlib.php
+++ b/docxlib.php
@@ -566,7 +566,7 @@ function offlinequiz_create_docx_question(question_usage_by_activity $templateus
             $questiontext = preg_replace('/<p[^>]+class="[^"]*"[^>]*>/i', "<p>", $questiontext);
 
             $questiontext = $trans->fix_image_paths($questiontext, $question->contextid, 'questiontext', $question->id,
-                                                    0.6, 300, 'docx');
+                                                    0.6, 300, $offlinequiz->disableimgnewlines, 'docx');
 
             $blocks = offlinequiz_convert_image_docx($questiontext);
             offlinequiz_print_blocks_docx($section, $blocks, $questionnumbering, 0);
@@ -597,7 +597,7 @@ function offlinequiz_create_docx_question(question_usage_by_activity $templateus
                     // Remove <script> tags that are created by mathjax preview.
                     $answertext = preg_replace("/<script[^>]*>[^<]*<\/script>/ms", "", $answertext);
                     $answertext = preg_replace("/<\/p[^>]*>/ms", "", $answertext);
-                    $answertext = $trans->fix_image_paths($answertext, $question->contextid, 'answer', $answer, 0.6, 200, 'docx');
+                    $answertext = $trans->fix_image_paths($answertext, $question->contextid, 'answer', $answer, 0.6, 200, $offlinequiz->disableimgnewlines, 'docx');
 
                     $blocks = offlinequiz_convert_image_docx($answertext);
                     offlinequiz_print_blocks_docx($section, $blocks, $answernumbering, 1);
@@ -654,7 +654,7 @@ function offlinequiz_create_docx_question(question_usage_by_activity $templateus
             $questiontext = preg_replace('/<p[^>]+class="[^"]*"[^>]*>/i', "<p>", $questiontext);
 
             $questiontext = $trans->fix_image_paths($questiontext, $question->contextid, 'questiontext', $question->id,
-                                                    0.6, 300, 'docx');
+                                                    0.6, 300, $offlinequiz->disableimgnewlines, 'docx');
 
             $blocks = offlinequiz_convert_image_docx($questiontext);
 
@@ -693,7 +693,7 @@ function offlinequiz_create_docx_question(question_usage_by_activity $templateus
                     // Remove <script> tags that are created by mathjax preview.
                     $answertext = preg_replace("/<script[^>]*>[^<]*<\/script>/ms", "", $answertext);
                     $answertext = preg_replace("/<\/p[^>]*>/ms", "", $answertext);
-                    $answertext = $trans->fix_image_paths($answertext, $question->contextid, 'answer', $answer, 0.6, 200, 'docx');
+                    $answertext = $trans->fix_image_paths($answertext, $question->contextid, 'answer', $answer, 0.6, 200, $offlinequiz->disableimgnewlines, 'docx');
 
                     $blocks = offlinequiz_convert_image_docx($answertext);
 

--- a/html2text.php
+++ b/html2text.php
@@ -47,7 +47,7 @@ class offlinequiz_html_translator
      * @param int $maxwidth The maximum width in pixels for images.
      * @return string The result string
      */
-    public function fix_image_paths($input, $contextid, $filearea, $itemid, $kfactor, $maxwidth, $format = 'pdf') {
+    public function fix_image_paths($input, $contextid, $filearea, $itemid, $kfactor, $maxwidth, $disableimgnewlines, $format = 'pdf') {
         global $CFG, $DB;
 
         require_once($CFG->dirroot.'/filter/tex/lib.php');
@@ -224,8 +224,9 @@ class offlinequiz_html_translator
                         // Add filename to list of temporary files.
                         $this->tempfiles[] = $file;
 
+
                         // In answer texts we want a line break to avoid the picture going above the line.
-                        if ($filearea == 'answer') {
+                        if ($filearea == 'answer' and $disableimgnewlines == 0) {
                             $output .= '<br/>';
                         }
 

--- a/lang/en/offlinequiz.php
+++ b/lang/en/offlinequiz.php
@@ -667,3 +667,6 @@ $string['withselected'] = 'With selected...';
 $string['zipfile'] = 'ZIP file';
 $string['zipok'] = 'ZIP file imported';
 $string['zerogradewarning'] = 'Warning: Your offline quiz grade is 0.0!';
+$string['disableimgnewlines'] = 'Disable new lines before and after images';
+$string['disableimgnewlines_help'] = 'This option removes extra new lines surrounding images. It will also move the a/b/c... from left upper corner of the image into the left down corner of image answear. Helpful in quizzes containing LaTeX formulas.';
+$string['configdisableimgnewlines'] = 'This will also move the a/b/c... from over the image into the left down corner of image answear';

--- a/mod_form.php
+++ b/mod_form.php
@@ -180,6 +180,10 @@ class mod_offlinequiz_mod_form extends moodleform_mod {
         $mform->addElement('select', 'showquestioninfo', get_string("showquestioninfo", "offlinequiz"), $options, $attribs);
         $mform->addHelpButton('showquestioninfo', "showquestioninfo", "offlinequiz");
 
+        $mform->addElement('selectyesno', 'disableimgnewlines', get_string("disableimgnewlines", "offlinequiz"), $attribs);
+        $mform->addHelpButton('disableimgnewlines', 'disableimgnewlines', 'offlinequiz');
+        $mform->setDefault('disableimgnewlines', $offlinequizconfig->disableimgnewlines);
+
         // -------------------------------------------------------------------------------
         $mform->addElement('header', 'reviewoptionshdr', get_string("reviewoptions", "offlinequiz"));
         $mform->addHelpButton('reviewoptionshdr', 'reviewoptions', 'offlinequiz');

--- a/pdflib.php
+++ b/pdflib.php
@@ -581,7 +581,7 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
             // Remove all class info from paragraphs because TCPDF won't use CSS.
             $questiontext = preg_replace('/<p[^>]+class="[^"]*"[^>]*>/i', "<p>", $questiontext);
 
-            $questiontext = $trans->fix_image_paths($questiontext, $question->contextid, 'questiontext', $question->id, 1, 300);
+            $questiontext = $trans->fix_image_paths($questiontext, $question->contextid, 'questiontext', $question->id, 1, 300, $offlinequiz->disableimgnewlines);
 
             $html = '';
 
@@ -606,7 +606,7 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
                     // Remove <script> tags that are created by mathjax preview.
                     $answertext = preg_replace("/<script[^>]*>[^<]*<\/script>/ms", "", $answertext);
                     $answertext = preg_replace("/<\/p[^>]*>/ms", "", $answertext);
-                    $answertext = $trans->fix_image_paths($answertext, $question->contextid, 'answer', $answer, 1, 300);
+                    $answertext = $trans->fix_image_paths($answertext, $question->contextid, 'answer', $answer, 1, 300, $offlinequiz->disableimgnewlines);
 
                     if ($correction) {
                         if ($question->options->answers[$answer]->fraction > 0) {
@@ -634,7 +634,12 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
                 }
 
             }
-
+            if ($offlinequiz->disableimgnewlines) {
+                //This removes span attribute added by TEX filter which created extra line break after every LATEX formula.
+                $html = preg_replace("/(<span class=\"MathJax_Preview\">.+?)+(title=\"TeX\" >)/ms", "", $html);
+                $html = preg_replace("/<\/a><\/span>/ms", "", $html);
+                $html = preg_replace("/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/ms", "", $html);
+            }
             // Finally print the question number and the HTML string.
             if ($question->qtype == 'multichoice' || $question->qtype == 'multichoiceset') {
                 $pdf->SetFont('FreeSans', 'B', $offlinequiz->fontsize);
@@ -712,7 +717,7 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
             // Remove all class info from paragraphs because TCPDF won't use CSS.
             $questiontext = preg_replace ( '/<p[^>]+class="[^"]*"[^>]*>/i', "<p>", $questiontext );
 
-            $questiontext = $trans->fix_image_paths ( $questiontext, $question->contextid, 'questiontext', $question->id, 1, 300 );
+            $questiontext = $trans->fix_image_paths ( $questiontext, $question->contextid, 'questiontext', $question->id, 1, 300, $offlinequiz->disableimgnewlines );
 
             $html = '';
 
@@ -740,7 +745,7 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
                     // Remove <script> tags that are created by mathjax preview.
                     $answertext = preg_replace ( "/<script[^>]*>[^<]*<\/script>/ms", "", $answertext );
                     $answertext = preg_replace ( "/<\/p[^>]*>/ms", "", $answertext );
-                    $answertext = $trans->fix_image_paths ( $answertext, $question->contextid, 'answer', $answer, 1, 300 );
+                    $answertext = $trans->fix_image_paths ( $answertext, $question->contextid, 'answer', $answer, 1, 300, $offlinequiz->disableimgnewlines );
 
                     if ($correction) {
                         if ($question->options->answers[$answer]->fraction > 0) {
@@ -772,6 +777,13 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
                 $pdf->SetFont ( 'FreeSans', 'B', $offlinequiz->fontsize );
                 $pdf->Cell ( 4, round ( $offlinequiz->fontsize / 2 ), "$number)  ", 0, 0, 'R' );
                 $pdf->SetFont ( 'FreeSans', '', $offlinequiz->fontsize );
+            }
+
+            //This removes span attribute added by TEX filter which created extra line break after every LATEX formula.
+            if ($offlinequiz->disableimgnewlines) {
+                $html = preg_replace("/(<span class=\"MathJax_Preview\">.+?)+(title=\"TeX\" >)/ms", "", $html);
+                $html = preg_replace("/<\/a><\/span>/ms", "", $html);
+                $html = preg_replace("/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/ms", "", $html);
             }
 
             $pdf->writeHTMLCell ( 165, round ( $offlinequiz->fontsize / 2 ), $pdf->GetX (), $pdf->GetY () + 0.3, $html );

--- a/settings.php
+++ b/settings.php
@@ -67,6 +67,11 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_heading('reviewheading',
             get_string('reviewoptionsheading', 'offlinequiz'), ''));
 
+    // Disable newlines around images.
+    $settings->add(new admin_setting_configcheckbox('offlinequiz/disableimgnewlines',
+            get_string('disableimgnewlines', 'offlinequiz'), get_string('configdisableimgnewlines', 'offlinequiz'),
+            0));
+
     foreach (mod_offlinequiz_admin_review_setting::fields() as $field => $name) {
         $default = mod_offlinequiz_admin_review_setting::all_on();
         $forceduring = null;


### PR DESCRIPTION
fix for latex misalignment in pdf files documented in issue #19
With global and local setting to enable/disable the new behavior.
