### PR TITLE
Improved latex template

### DIFF
--- a/lang/de/offlinequiz.php
+++ b/lang/de/offlinequiz.php
@@ -422,8 +422,11 @@ $string['questioninfoqtype'] = 'Fragetyp zeigen';
 $string['questioninfomultichoice'] = 'Multiple-Choice';
 $string['questionname'] = 'Frage';
 $string['questionsheet'] = 'Fragebogen';
-$string['questionsheetlatextemplate'] = '\documentclass[12pt,a4paper]{article}
+$string['questionsheetlatextemplate'] = '% !TEX encoding = UTF-8 Unicode
+\documentclass[11pt,a4paper]{article}
 \usepackage[ngerman]{babel}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
 \textwidth 16truecm
 \textheight 23truecm
 \setlength{\oddsidemargin}{0cm}
@@ -436,16 +439,23 @@ $string['questionsheetlatextemplate'] = '\documentclass[12pt,a4paper]{article}
 \newcommand{\lsim}{\mbox{\raisebox{-.3em}{$\stackrel{<}{\sim}$}}} % less or approximately equal
 \newcommand{\subs}{\mbox{\raisebox{-.5em}{$\stackrel{\subset}{\neq}$}}}
 \newcommand{\sei}{\mbox{\raisebox{.0em}{$\stackrel{!}{=}$}}}
+\newcommand{\I}{\mathrm{i}}
+\newcommand{\E}{\mathrm{e}}
+\newcommand{\Q}{{\mathbb Q}}
+\newcommand{\R}{{\mathbb R}}
+\newcommand{\N}{{\mathbb N}}
+\newcommand{\Z}{{\mathbb Z}}
+\newcommand{\C}{{\mathbb C}}
 \parindent 0pt % keine Einrückung am Beginn des Absatzes
 \usepackage{esvect} % für lange Vektorpfeile, z.B. \vv{AB}
 \usepackage[colorlinks=true,urlcolor=dunkelrot,linkcolor=black]{hyperref} % Für Einfügen von Hyperlinks
-\renewcommand\UrlFont{\sf}
 \usepackage{ulem} % Durchstreichen: \sout{gerade durchstreichen} \xout{schräg durchstreichen}
 \newcommand{\abs}[1]{\left\lvert#1\right\rvert}
-\usepackage{scrpage2} % Kopf- und Fußzeilen (http://esc-now.de/_/latex-individuelle-kopf-und-fusszeilen/?lang=en):
-\pagestyle{scrheadings}
-\clearscrheadfoot
-\ifoot{[Gruppe \Group]}
+\usepackage{lastpage}
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\chead{\sc \Title, Gruppe \Group}
+\cfoot{Seite \thepage/\pageref{LastPage}}
 \makeatletter %%% Seitenumbrüche zwischen Antwortmöglichkeiten unterdrücken (funktioniert meistens!)
 \@beginparpenalty=10000
 \@itempenalty=10000
@@ -456,24 +466,40 @@ $string['questionsheetlatextemplate'] = '\documentclass[12pt,a4paper]{article}
 % \newcommand{\answerIs}[1]{[#1]} %%% Zum Anzeigen der richtigen und falschen Antworten
 %%%
 
-\begin{document}
-
-
-
 % ===========================================================================================================
 %%% Die Lehrveranstaltungs-Daten:
-\begin{center}{\LARGE {$a->coursename}}\end{center}
-\begin{center}{Schriftliche Pr\"ufung {$a->date}}\end{center}
-%%%
-\def\Group{{$a->groupname}}
-\begin{center}{\Large Gruppe \Group}\end{center}
+\newcommand{\Group}{{$a->groupname}}
+\newcommand{\Title}{{$a->coursename}}
+\newcommand{\Date}{$a->date}
 
-{\bf Name:}\\\\
-{\bf Matrikelnummer:}\\\\
-{\bf Unterschrift:}\\
+\begin{document}
+% ===========================================================================================================
+
+
 
 % ===========================================================================================================
+
+\begin{center}
+{\bf \Large Fragebogen}\\[3mm]
+\fbox{
+\begin{tabular}{rl}
+\rule{0pt}{25pt} Name: & $\underline{\hspace*{8cm}}$ \rule{20pt}{0pt}\\[5mm]
+Matrikelnummer: & $\underline{\hspace*{8cm}}$\\[5mm]
+%\rule{10pt}{0pt} Studienkennzahl: & $\underline{\hspace*{8cm}}$\\[5mm]
+\rule[-20pt]{0pt}{20pt} Unterschrift: & $\underline{\hspace*{8cm}}$
+\end{tabular}}
+\end{center}
+
 \bigskip
+% ===========================================================================================================
+
+{$a->pdfintrotext}
+
+% ===========================================================================================================
+
+\newpage
+
+% ===========================================================================================================
 
 {$a->latexforquestions}
 

--- a/lang/en/offlinequiz.php
+++ b/lang/en/offlinequiz.php
@@ -454,7 +454,7 @@ $string['questionsheetlatextemplate'] = '% !TEX encoding = UTF-8 Unicode
 \usepackage{amsmath} % for \implies etc
 \usepackage{amsfonts} % for \mathbb etc
 \usepackage{graphicx} % for including pictures
-\renewcommand{\familydefault}{\sfdefault} % Sfont
+\renewcommand{\familydefault}{\sfdefault} % Font
 \newcommand{\lsim}{\mbox{\raisebox{-.3em}{$\stackrel{<}{\sim}$}}} % less or approximately equal
 \newcommand{\subs}{\mbox{\raisebox{-.5em}{$\stackrel{\subset}{\neq}$}}}
 \newcommand{\sei}{\mbox{\raisebox{.0em}{$\stackrel{!}{=}$}}}

--- a/lang/en/offlinequiz.php
+++ b/lang/en/offlinequiz.php
@@ -444,7 +444,6 @@ $string['questionname'] = 'Question name';
 $string['questionsheet'] = 'Question sheet';
 $string['questionsheetlatextemplate'] = '% !TEX encoding = UTF-8 Unicode
 \documentclass[11pt,a4paper]{article}
-\usepackage[ngerman]{babel}
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 \textwidth 16truecm

--- a/lang/en/offlinequiz.php
+++ b/lang/en/offlinequiz.php
@@ -442,7 +442,11 @@ $string['questioninfonone'] = 'Nothing';
 $string['questioninfoqtype'] = 'Question type';
 $string['questionname'] = 'Question name';
 $string['questionsheet'] = 'Question sheet';
-$string['questionsheetlatextemplate'] = '\documentclass[12pt,a4paper]{article}
+$string['questionsheetlatextemplate'] = '% !TEX encoding = UTF-8 Unicode
+\documentclass[11pt,a4paper]{article}
+\usepackage[ngerman]{babel}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
 \textwidth 16truecm
 \textheight 23truecm
 \setlength{\oddsidemargin}{0cm}
@@ -451,20 +455,28 @@ $string['questionsheetlatextemplate'] = '\documentclass[12pt,a4paper]{article}
 \usepackage{amsmath} % for \implies etc
 \usepackage{amsfonts} % for \mathbb etc
 \usepackage{graphicx} % for including pictures
-\renewcommand{\familydefault}{\sfdefault} % Font
+\renewcommand{\familydefault}{\sfdefault} % Sfont
 \newcommand{\lsim}{\mbox{\raisebox{-.3em}{$\stackrel{<}{\sim}$}}} % less or approximately equal
 \newcommand{\subs}{\mbox{\raisebox{-.5em}{$\stackrel{\subset}{\neq}$}}}
 \newcommand{\sei}{\mbox{\raisebox{.0em}{$\stackrel{!}{=}$}}}
+\newcommand{\I}{\mathrm{i}}
+\newcommand{\E}{\mathrm{e}}
+\newcommand{\Q}{{\mathbb Q}}
+\newcommand{\R}{{\mathbb R}}
+\newcommand{\N}{{\mathbb N}}
+\newcommand{\Z}{{\mathbb Z}}
+\newcommand{\C}{{\mathbb C}}
 \parindent 0pt % no indent on the beginning of a section
 \usepackage{esvect} % long vector arrows, e.g. \vv{AB}
 \usepackage[colorlinks=true,urlcolor=dunkelrot,linkcolor=black]{hyperref} % For using of Hyperlinks
 \renewcommand\UrlFont{\sf}
 \usepackage{ulem} %  \sout{horizontal cross out} \xout{diagonal strike out}
 \newcommand{\abs}[1]{\left\lvert#1\right\rvert}
-\usepackage{scrpage2} % For Header and Footer
-\pagestyle{scrheadings}
-\clearscrheadfoot
-\ifoot{[Gruppe \Group]}
+\usepackage{lastpage}
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\chead{\sc \Title, Gruppe \Group}
+\cfoot{Seite \thepage/\pageref{LastPage}}
 \makeatletter %%% disable pagebreaks between answers
 \@beginparpenalty=10000
 \@itempenalty=10000
@@ -474,24 +486,40 @@ $string['questionsheetlatextemplate'] = '\documentclass[12pt,a4paper]{article}
 % \newcommand{\answerIs}[1]{[#1]} %%%Enable showing the right answer
 %%%
 
+% ===========================================================================================================
+%%% Course data:
+\newcommand{\Group}{{$a->groupname}}
+\newcommand{\Title}{{$a->coursename}}
+\newcommand{\Date}{$a->date}
+
 \begin{document}
+% ===========================================================================================================
 
 
 
 % ===========================================================================================================
-%%% Data of the Course
-\begin{center}{\LARGE {$a->coursename}}\end{center}
-\begin{center}{Written Exam {$a->date}}\end{center}
-%%%
-\def\Group{{$a->groupname}}
-\begin{center}{\Large Group \Group}\end{center}
 
-{\bf Name:}\\\\
-{\bf Matriculation number:}\\\\
-{\bf Signature:}\\
+\begin{center}
+{\bf \Large Questionnaire}\\[3mm]
+\fbox{
+\begin{tabular}{rl}
+\rule{0pt}{25pt} Name: & $\underline{\hspace*{8cm}}$ \rule{20pt}{0pt}\\[5mm]
+Student ID: & $\underline{\hspace*{8cm}}$\\[5mm]
+%\rule{10pt}{0pt} Program code: & $\underline{\hspace*{8cm}}$\\[5mm]
+\rule[-20pt]{0pt}{20pt} Signature: & $\underline{\hspace*{8cm}}$
+\end{tabular}}
+\end{center}
 
-% ===========================================================================================================
 \bigskip
+% ===========================================================================================================
+
+{$a->pdfintrotext}
+
+% ===========================================================================================================
+
+\newpage
+
+% ===========================================================================================================
 
 {$a->latexforquestions}
 

--- a/latexlib.php
+++ b/latexlib.php
@@ -169,6 +169,7 @@ function offlinequiz_create_latex_question(question_usage_by_activity $templateu
     $a['latexforquestions'] = $latexforquestions;
     $a['coursename'] = offlinequiz_convert_html_to_latex($course->fullname);
     $a['groupname'] = $groupletter;
+    $latex = offlinequiz_convert_html_to_latex(get_string('pdfintrotext', 'offlinequiz', $a));
     // TODO exceptionhandling?
     if ($offlinequiz->time) {
         $a['date'] = ', ' . userdate($offlinequiz->time);
@@ -226,6 +227,7 @@ function offlinequiz_convert_html_to_latex($text) {
     		'</i>' => '}',
     		'<u>' => '\underline{',
     		'</u>' => '}',
+    		'<br>' => '\medskip',
     		'&gt;' => '>',
     		'&lt;' => '<',
         '$$' => '$'


### PR DESCRIPTION
Ich habe versucht das LaTeX-Template zu verbessern. Sieht nun eher wie die PDF-Vorlage aus. Insbesondere gibt es eine Titelseite mit einer Box zum ausfüllen und der Hilfetext aus den Formulareinstellungen sollte nun auch übernommen werden. Leider ist das im Blindflug erstellt, da ich keine einfache Möglichkeit habe das zu testen (das LaTeX-File schon, aber den Code nicht). Es würde uns an der Mathematik das Leben sehr erleichtern, wenn man das übernimmt! Danke, Gerald Teschl