### PR TITLE
Fix DELETE query

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1423,13 +1423,12 @@ function xmldb_offlinequiz_upgrade($oldversion = 0) {
         if (!$dbman->index_exists($table, $index2)) {
             $dbman->add_index($table, $index2);
         }
-        $sql = 'DELETE c1.*
-                FROM   mdl_offlinequiz_choices c1,
-                       mdl_offlinequiz_choices c2
-                WHERE  c1.scannedpageid = c2.scannedpageid
-                AND    c1.slotnumber = c2.slotnumber
-                AND    c1.choicenumber = c2.choicenumber
-                AND    c1.id < c2.id';
+        $sql = 'DELETE
+				  FROM {offlinequiz_choices} c1
+				 WHERE (c1.scannedpageid, c1.slotnumber, c1.choicenumber)
+					in (select c2.scannedpageid,c2.slotnumber,c2.choicenumber
+						  from {offlinequiz_choices} c2
+						 where c1.id < c2.id)';
         $DB->execute($sql);
         upgrade_mod_savepoint(true, 2018112700, 'offlinequiz');
     }


### PR DESCRIPTION
When I try to upgrade the plugin from 3.5.4 to 3.6.0 I get an error:

`Debug info: ERROR: syntax error at or near "c1"
LINE 1: DELETE c1.*
^
DELETE c1.*
FROM mdl_offlinequiz_choices c1,
mdl_offlinequiz_choices c2
WHERE c1.scannedpageid = c2.scannedpageid
AND c1.slotnumber = c2.slotnumber
AND c1.choicenumber = c2.choicenumber
AND c1.id < c2.id
[array (
)]`
Error code: dmlwriteexception
Stack trace:
`
    line 489 of /lib/dml/moodle_database.php: dml_write_exception thrown
    line 248 of /lib/dml/pgsql_native_moodle_database.php: call to moodle_database->query_end()
    line 708 of /lib/dml/pgsql_native_moodle_database.php: call to pgsql_native_moodle_database->query_end()
    line 1433 of /mod/offlinequiz/db/upgrade.php: call to pgsql_native_moodle_database->execute()
    line 807 of /lib/upgradelib.php: call to xmldb_offlinequiz_upgrade()
    line 518 of /lib/upgradelib.php: call to upgrade_plugins_modules()
    line 1852 of /lib/upgradelib.php: call to upgrade_plugins()
    line 694 of /admin/index.php: call to upgrade_noncore()`
`
There are two issues in that query:
- The table prefix (mdl_) is hardcoded
- The way the delete is done it's not SQL standard. Something like works on PostgreSQL and should work for any DBMS:
`DELETE
  FROM {offlinequiz_choices} c1
 WHERE (c1.scannedpageid, c1.slotnumber, c1.choicenumber)
    in (select c2.scannedpageid,c2.slotnumber,c2.choicenumber
	      from {offlinequiz_choices} c2
		 where c1.id < c2.id)`

