### PR TITLE
Fix broken image links in 'Show student view' popup

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -230,6 +230,11 @@ class mod_offlinequiz_mod_form extends moodleform_mod {
 
         $language = current_language();
 
+        if (is_dir($CFG->dirroot.'/mod/offlinequiz/pix/studentview/'.$language) === false) {
+            // If current language not supported, fall back to english.
+            $language = 'en';
+        }
+
         $mform->addElement('html', '<input id="showviewbutton" type="button" class="btn btn-secondary" value="'.
                 get_string('showstudentview', 'offlinequiz') . '" onClick="showStudentView(); return false;">');
         $mform->addElement('html', '<div class="Popup"><center><input type="button" class="closePopup btn btn-primary"' .


### PR DESCRIPTION
When Moodle instance doesn't use german or english language, there are some broken image links in 'Show student view' popup.
This patch fallback to english directory to display images when "current_language()" directory doesn't exist.
