### PR TITLE
Moodle 34 ostfalia

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,11 @@
 CHANGELOG
 =========
+3.4.2 Ostfalia (2018-07-12)
+------------------
+* button for import of unassigned users as dummy users
+* support for images in tex output by using pdflatex
+* minor changes in tex output
+
 3.4.2 (2018-04-10)
 ------------------
 * changed the way how LaTeX-Question sheets work. It should now support almost every question that is written in the moodle editor

--- a/createquiz.php
+++ b/createquiz.php
@@ -421,7 +421,16 @@ if ($mode == 'preview') {
                     $questionfile = offlinequiz_create_docx_question($templateusage, $offlinequiz, $group, $course->id, $context);
                 } else if ($offlinequiz->fileformat == OFFLINEQUIZ_LATEX_FORMAT) {
                     require_once('latexlib.php');
-                    $questionfile = offlinequiz_create_latex_question($templateusage, $offlinequiz, $group, $course->id, $context);
+		    // get array of result files for latex (pdf, tex, log) // OSTFALIA
+                    // array('pdf' => $pdf, 'source' => $tex, 'log' => $log);
+                    $resultfiles = offlinequiz_create_latex_question($templateusage, $offlinequiz, $group, $course->id, $context);
+                    $questionfile = $resultfiles['pdf'];
+                    if ($questionfile == null)
+                        $questionfile = $resultfiles['source'];
+                    if ($questionfile == null)
+                        $questionfile = $resultfiles['log'];
+
+//                    $questionfile = offlinequiz_create_latex_question($templateusage, $offlinequiz, $group, $course->id, $context);
                 } else {
                     $questionfile = offlinequiz_create_pdf_question($templateusage, $offlinequiz, $group, $course->id, $context);
                 }
@@ -445,6 +454,27 @@ if ($mode == 'preview') {
                             '/' . $questionfile->get_filearea() . '/' . $questionfile->get_itemid() . '/' .
                             $questionfile->get_filename() . '?forcedownload=1';
                 echo $OUTPUT->action_link($url, $filestring);
+		// output of all latex result files // OSTFALIA
+                echo '<br />&nbsp;<br />';
+
+                if (isset($resultfiles)) {
+                    if (isset($resultfiles['source']) && isset($resultfiles['pdf'])) {
+                        $source = $resultfiles['source'];
+                        $url = "$CFG->wwwroot/pluginfile.php/" . $source->get_contextid() . '/' . $source->get_component() .
+                                '/' . $source->get_filearea() . '/' . $source->get_itemid() . '/' .
+                                $source->get_filename() . '?forcedownload=1';
+                        echo $OUTPUT->action_link($url, 'Source') . '<br>';
+                    }
+
+                    if (isset($resultfiles['log'])) {
+                        $logfile = $resultfiles['log'];
+                        $url = "$CFG->wwwroot/pluginfile.php/" . $logfile->get_contextid() . '/' . $logfile->get_component() .
+                                '/' . $logfile->get_filearea() . '/' . $logfile->get_itemid() . '/' .
+                                $logfile->get_filename() . '?forcedownload=1';
+                        echo $OUTPUT->action_link($url, 'Log-File');
+                    }
+                }
+
                 echo '<br />&nbsp;<br />';
                 @flush();@ob_flush();
             } else {

--- a/html2text.php
+++ b/html2text.php
@@ -132,6 +132,10 @@ class offlinequiz_html_translator
                             $latex = new latex();
                             $density = $DB->get_field('config_plugins', 'value', array('plugin' => 'filter_tex',
                                 'name' => 'density'));
+			    // OSTFALIA
+                            // avoid too small density which creates small images with low resolution
+                            if ($density < 240)
+                                $density = 240;
                             $background = $DB->get_field('config_plugins', 'value', array('plugin' => 'filter_tex',
                                 'name' => 'latexbackground'));
                             $texexp = $texcache->rawtext; // The entities are now decoded before inserting to DB.
@@ -148,6 +152,10 @@ class offlinequiz_html_translator
                                 $texexp = '\Large '.$texexp;
                                 $cmd = filter_tex_get_cmd($teximagefile, $texexp);
                                 system($cmd, $status);
+                            }
+			    // print error message, OSTFALIA
+                            if (!file_exists($teximagefile)) {
+                                echo 'could not create image for ' . $texexp;
                             }
                         }
                     }
@@ -185,7 +193,9 @@ class offlinequiz_html_translator
                             if ($percent < 100) {
                                 $resize = ' -resize '.$percent.'%';
                             }
-                            $handle = popen($pathconvert . ' ' . $file . $resize . ' -background white -flatten +matte ' .
+                            // $handle = popen($pathconvert . ' ' . $file . $resize . ' -background white -flatten +matte ' .
+                            // no flatten and no matte because this results in an invalid pdf file :-(
+                            $handle = popen($pathconvert . ' ' . $file . $resize . ' -background white   ' .
                                     $newfile, 'r');
                             pclose($handle);
                             $this->tempfiles[] = $file;

--- a/lang/de/offlinequiz.php
+++ b/lang/de/offlinequiz.php
@@ -424,7 +424,7 @@ $string['questioninfomultichoice'] = 'Multiple-Choice';
 $string['questionname'] = 'Frage';
 $string['questionsheet'] = 'Fragebogen';
 $string['questionsheetlatextemplate'] = '% !TEX encoding = UTF-8 Unicode
-\documentclass[11pt,a4paper]{article}
+\documentclass[{$a->fontsize}pt,a4paper]{extarticle}
 \usepackage[ngerman]{babel}
 \usepackage[utf8x]{inputenc}
 \usepackage[T1]{fontenc}
@@ -433,11 +433,13 @@ $string['questionsheetlatextemplate'] = '% !TEX encoding = UTF-8 Unicode
 \setlength{\oddsidemargin}{0cm}
 \setlength{\evensidemargin}{0cm}
 \setlength{\topmargin}{-1cm}
+\usepackage{float} % für Bildposition
 \usepackage{amsmath} % für \implies etc
 \usepackage{amsfonts} % für \mathbb etc
 \usepackage{graphicx} % zum Bilder einfügen
 \usepackage{enumitem}
 \usepackage{xcolor}
+\usepackage{multicol} % für Möglichkeit der mehrspaltigen Ausgabe 
 \usepackage{ulem}
 \parindent 0pt % keine Einrückung am Beginn des Absatzes
 \renewcommand{\familydefault}{\sfdefault} % Schriftart
@@ -671,3 +673,6 @@ $string['quizfor'] = 'Test für Offline-Test';
 $string['quizquestions'] = 'Test-Fragen';
 $string['groupquestions'] = 'Bearbeiten';
 $string['reordergroupquestions'] = 'Gruppen-Fragen <br/> Reihenfolge und Seitenumbrüche';
+$string['pathpdflatex'] = 'Pfad zu pdflatex';
+$string['pathpdflatex_help'] = 'zum Erzeugen von pdf bei Nutzung von TeX';
+

--- a/lang/en/offlinequiz.php
+++ b/lang/en/offlinequiz.php
@@ -444,7 +444,7 @@ $string['questioninfoqtype'] = 'Question type';
 $string['questionname'] = 'Question name';
 $string['questionsheet'] = 'Question sheet';
 $string['questionsheetlatextemplate'] = '% !TEX encoding = UTF-8 Unicode
-\documentclass[11pt,a4paper]{article}
+\documentclass[{$a->fontsize}pt,a4paper]{extarticle}
 \usepackage[utf8x]{inputenc}
 \usepackage[T1]{fontenc}
 \textwidth 16truecm
@@ -452,11 +452,14 @@ $string['questionsheetlatextemplate'] = '% !TEX encoding = UTF-8 Unicode
 \setlength{\oddsidemargin}{0cm}
 \setlength{\evensidemargin}{0cm}
 \setlength{\topmargin}{-1cm}
+\usepackage{float} % for image positions
 \usepackage{amsmath} % for \implies etc
 \usepackage{amsfonts} % for \mathbb etc
+\usepackage{graphicx} % for imserting images
 \usepackage[colorlinks=true,urlcolor=dunkelrot,linkcolor=black]{hyperref} % For using hyperlinks
 \usepackage{enumitem}
 \usepackage{xcolor}
+\usepackage{multicol} % for multi column
 \usepackage{ulem}
 \parindent 0pt % no indent on the beginning of a section
 \renewcommand\UrlFont{\sf}
@@ -695,3 +698,6 @@ $string['withselected'] = 'With selected...';
 $string['zipfile'] = 'ZIP file';
 $string['zipok'] = 'ZIP file imported';
 $string['zerogradewarning'] = 'Warning: Your offline quiz grade is 0.0!';
+$string['pathpdflatex'] = 'path of pdflatex binary';
+$string['pathpdflatex_help'] = 'for creating pdf in case of use of tex';
+

--- a/latexlib.php
+++ b/latexlib.php
@@ -86,128 +86,213 @@ function offlinequiz_create_latex_question(question_usage_by_activity $templateu
 
     $number = 1;
 
-    // We need a mapping from question IDs to slots, assuming that each question occurs only once.
-    $slots = $templateusage->get_slots();
-    $latexforquestions = '\begin{enumerate}' . "\n";
-    // If shufflequestions has been activated we go through the questions in the order determined by
-    // the template question usage.
-    if ($offlinequiz->shufflequestions) {
-        foreach ($slots as $slot) {
-            $slotquestion = $templateusage->get_question($slot);
-            $currentquestionid = $slotquestion->id;
+    $trans = new offlinequiz_html_translator();
+    $tmppath = null;
 
-            $question = $questions[$currentquestionid];
+    try {
+        // We need a mapping from question IDs to slots, assuming that each question occurs only once.
+        $slots = $templateusage->get_slots();
+        $latexforquestions = '\begin{enumerate}' . "\n";
+        // If shufflequestions has been activated we go through the questions in the order determined by
+        // the template question usage.
+        if ($offlinequiz->shufflequestions) {
+            foreach ($slots as $slot) {
+                $slotquestion = $templateusage->get_question($slot);
+                $currentquestionid = $slotquestion->id;
 
-            $questiontext = offlinequiz_convert_html_to_latex($question->questiontext);
+                $question = $questions[$currentquestionid];
 
-            $latexforquestions .= '\item ' .  $questiontext . "\n";
+                $questiontext = $trans->fix_image_paths($question->questiontext, $question->contextid,
+                        'questiontext', $question->id, 1, 300, $offlinequiz->disableimgnewlines, 'latex');
+                $questiontext = offlinequiz_convert_html_to_latex($questiontext);
 
-            if ($question->qtype == 'multichoice' || $question->qtype == 'multichoiceset') {
+                $latexforquestions .= '\item ' .  $questiontext . "\n";
 
-                // There is only a slot for multichoice questions.
-                $attempt = $templateusage->get_question_attempt($slot);
-                $order = $slotquestion->get_order($attempt);  // Order of the answers.
+                if ($question->qtype == 'multichoice' || $question->qtype == 'multichoiceset') {
 
-                $latexforquestions .= '\begin{enumerate}' . " \n";
-                foreach ($order as $key => $answer) {
-                    $latexforquestions .= offlinequiz_get_answer_latex($question, $answer);
+                    // There is only a slot for multichoice questions.
+                    $attempt = $templateusage->get_question_attempt($slot);
+                    $order = $slotquestion->get_order($attempt);  // Order of the answers.
+
+                    $latexforquestions .= '\begin{enumerate}' . " \n";
+                    foreach ($order as $key => $answer) {
+                        $answertext = $question->options->answers[$answer]->answer;
+                        $answertext = $trans->fix_image_paths($answertext, $question->contextid, 'answer', $answer, 1, 300,
+                                $offlinequiz->disableimgnewlines, 'latex');
+                        $latexforquestions .= offlinequiz_get_answer_latex($question, $answertext, $answer);
+                    }
+                    $latexforquestions .= '\end{enumerate}' . "\n";
+
+                    $infostr = offlinequiz_get_question_infostring($offlinequiz, $question);
+                    if ($infostr) {
+                        $latexforquestions .= $infostr . "\n";
+                    }
                 }
-                $latexforquestions .= '\end{enumerate}' . "\n";
 
-                $infostr = offlinequiz_get_question_infostring($offlinequiz, $question);
-                if ($infostr) {
-                    $latexforquestions .= $infostr . "\n";
-                }
+            }
+            $latexforquestions .= '\end{enumerate}' . "\n";
+
+        } else {
+            // No shufflequestions, so go through the questions as they have been added to the offlinequiz group.
+            // We also have to show description questions that are not in the template.
+
+            // First, compute mapping  questionid -> slotnumber.
+            $questionslots = array();
+            foreach ($slots as $slot) {
+                $questionslots[$templateusage->get_question($slot)->id] = $slot;
             }
 
-        }
-        $latexforquestions .= '\end{enumerate}' . "\n";
+            foreach ($questions as $question) {
+                $currentquestionid = $question->id;
 
-    } else {
-        // No shufflequestions, so go through the questions as they have been added to the offlinequiz group.
-        // We also have to show description questions that are not in the template.
+                $questiontext = $trans->fix_image_paths($question->questiontext, $question->contextid,
+                        'questiontext', $question->id, 1, 300, $offlinequiz->disableimgnewlines, 'latex');
 
-        // First, compute mapping  questionid -> slotnumber.
-        $questionslots = array();
-        foreach ($slots as $slot) {
-            $questionslots[$templateusage->get_question($slot)->id] = $slot;
-        }
-
-        foreach ($questions as $question) {
-            $currentquestionid = $question->id;
-
-            $questiontext = $question->questiontext;
-            $questiontext = offlinequiz_convert_html_to_latex($question->questiontext);
-            if ($question->qtype == 'description') {
-                $latexforquestions .= "\n" . '\\ ' . $questiontext . "\n";
-            } else {
+                $questiontext = offlinequiz_convert_html_to_latex($questiontext);
+                if ($question->qtype == 'description') {
+                    $latexforquestions .= "\n" . '\\ ' . $questiontext . "\n";
+                } else {
             	$latexforquestions .= '\item %' .  $question->name . "\n" . $questiontext . "\n";
+                }
+                if ($question->qtype == 'multichoice' || $question->qtype == 'multichoiceset') {
+
+                    $slot = $questionslots[$currentquestionid];
+
+                    // There is only a slot for multichoice questions.
+                    $slotquestion = $templateusage->get_question ( $slot );
+                    $attempt = $templateusage->get_question_attempt ( $slot );
+                    $order = $slotquestion->get_order ( $attempt ); // Order of the answers.
+                    $latexforquestions .= '\begin{enumerate}' . " \n";
+                    foreach ($order as $key => $answer) {
+                        $answertext = $question->options->answers[$answer]->answer;
+                        $answertext = $trans->fix_image_paths($answertext, $question->contextid, 'answer', $answer, 1, 300,
+                                $offlinequiz->disableimgnewlines, 'latex');
+                        $latexforquestions .= offlinequiz_get_answer_latex($question, $answertext, $answer);
+
+                        //$latexforquestions .= offlinequiz_get_answer_latex($question, $answer);
+                    }
+                    $latexforquestions .= '\end{enumerate}' . "\n";
+                    $infostr = offlinequiz_get_question_infostring($offlinequiz, $question);
+                    if ($infostr) {
+                        $latexforquestions .= $infostr . "\n";
+                    }
+
+                }
             }
-            if ($question->qtype == 'multichoice' || $question->qtype == 'multichoiceset') {
+            $latexforquestions .= '\end{enumerate}' . "\n";
+        }
+        $a = array();
+        $a['latexforquestions'] = $latexforquestions;
+        $a['coursename'] = offlinequiz_convert_html_to_latex($offlinequiz->name); // $course->fullname);
+        $a['groupname'] = $groupletter;
+        $a['pdfintrotext'] = offlinequiz_convert_html_to_latex($offlinequiz->pdfintro);
+        if ($offlinequiz->time) {
+            $a['date'] = ', ' . userdate($offlinequiz->time);
+        } else {
+            $a['date'] = '';
+        }
+        $a['fontsize'] = $offlinequiz->fontsize;
+        if($offlinequiz->printstudycodefield) {
+    	    $a['printstudycodefield'] = "true";
+        } else {
+    	    $a['printstudycodefield'] = "false";
+        }
+        $latex = get_string('questionsheetlatextemplate', 'offlinequiz', $a);
+	
+        $fs = get_file_storage();
+        $fileprefix = get_string('fileprefixform', 'offlinequiz');
 
-                $slot = $questionslots[$currentquestionid];
+        // Prepare file record object.
+        $date = usergetdate(time());
+        $timestamp = sprintf('%04d%02d%02d_%02d%02d%02d',
+                $date['year'], $date['mon'], $date['mday'], $date['hours'], $date['minutes'], $date['seconds']);
 
-                // There is only a slot for multichoice questions.
-                $slotquestion = $templateusage->get_question ( $slot );
-                $attempt = $templateusage->get_question_attempt ( $slot );
-                $order = $slotquestion->get_order ( $attempt ); // Order of the answers.
-                $latexforquestions .= '\begin{enumerate}' . " \n";
-                foreach ($order as $key => $answer) {
-                    $latexforquestions .= offlinequiz_get_answer_latex($question, $answer);
-                }
-                $latexforquestions .= '\end{enumerate}' . "\n";
-                $infostr = offlinequiz_get_question_infostring($offlinequiz, $question);
-                if ($infostr) {
-                    $latexforquestions .= $infostr . "\n";
-                }
+        $tmppath = $CFG->dataroot . "/temp/offlinequiz/" . $fileprefix . '_' . $groupletter . '_' . $timestamp;
+        $filename = $tmppath . '.tex';
 
+
+        $offlinequizconfig = get_config('offlinequiz');
+
+        $fileinfo = array(
+                'contextid' => $context->id,
+                'component' => 'mod_offlinequiz',
+                'filearea' => 'pdfs',
+                'filepath' => '/',
+                'itemid' => 0);
+        //            'filename' => $fileprefix . '_' . $groupletter . '_' . $timestamp . '.tex');
+
+
+        $pdf = null;
+        $tex = null;
+        $log = null;
+        if ($offlinequizconfig->pathpdflatex) {
+            // create pdf from tex file
+
+            // write tex file
+            if (!file_put_contents ( $filename , $latex)) {
+                echo 'cannot create file ' . $filename . '<br>';
+            }
+
+            $logfile = $tmppath . '.log';
+            $pdffile = $tmppath . '.pdf';
+
+
+            $command = $offlinequizconfig->pathpdflatex . '  -output-directory ' . $CFG->dataroot . '/temp/offlinequiz ' .
+                    $filename . ' > /dev/null 2>&1';
+            // call twice in order to generate page numbers
+            if (system($command . ' && ' . $command) === FALSE) {
+                echo 'could not create pdf file from tex output<br>';
+            }
+
+            // echo 'Warning! Error creating pdf file ' . $pdffile . '<br>';
+            if (file_exists($logfile)) {
+                $fileinfo['filename'] = $fileprefix . '_' . $groupletter . '_' . $timestamp . '.log';
+                $log = create_persistent_file($fs, $fileinfo, null, $logfile);
+            }
+            $fileinfo['filename'] = $fileprefix . '_' . $groupletter . '_' . $timestamp . '.tex';
+            $tex = create_persistent_file($fs, $fileinfo, $latex);
+
+            if (file_exists($pdffile)) {
+                $fileinfo['filename'] = $fileprefix . '_' . $groupletter . '_' . $timestamp . '.pdf';
+                $pdf = create_persistent_file($fs, $fileinfo, null, $pdffile);
+            }
+        } else {
+            echo 'cannot create pdf file because pdflatex not defined<br>';
+
+            // create TeX file
+            $fileinfo['filename'] = $fileprefix . '_' . $groupletter . '_' . $timestamp . '.tex';
+            $tex = create_persistent_file($fs, $fileinfo, $latex);
+        }
+        return array('pdf' => $pdf, 'source' => $tex, 'log' => $log);
+    } finally {
+        // remove temporary files
+        if (isset($tmppath)) {
+            foreach (glob($tmppath . '.*') as $filename) {
+                unlink($filename);
             }
         }
-        $latexforquestions .= '\end{enumerate}' . "\n";
+        $trans->remove_temp_files();
     }
-    $a = array();
-    $a['latexforquestions'] = $latexforquestions;
-    $a['coursename'] = offlinequiz_convert_html_to_latex($course->fullname);
-    $a['groupname'] = $groupletter;
-    $a['pdfintrotext'] = offlinequiz_convert_html_to_latex(get_string('pdfintrotext', 'offlinequiz', $a));
-    if ($offlinequiz->time) {
-        $a['date'] = ', ' . userdate($offlinequiz->time);
-    } else {
-        $a['date'] = '';
-    }
-    $a['fontsize'] = $offlinequiz->fontsize;
-    if($offlinequiz->printstudycodefield) {
-    	$a['printstudycodefield'] = "true";
-    } else {
-    	$a['printstudycodefield'] = "false";
-    }
-    
-    $latex = get_string('questionsheetlatextemplate', 'offlinequiz', $a);
+}
 
-    $fs = get_file_storage();
-    $fileprefix = get_string('fileprefixform', 'offlinequiz');
 
-    // Prepare file record object.
-    $date = usergetdate(time());
-    $timestamp = sprintf('%04d%02d%02d_%02d%02d%02d',
-            $date['year'], $date['mon'], $date['mday'], $date['hours'], $date['minutes'], $date['seconds']);
-
-    $fileinfo = array(
-            'contextid' => $context->id,
-            'component' => 'mod_offlinequiz',
-            'filearea' => 'pdfs',
-            'filepath' => '/',
-            'itemid' => 0,
-            'filename' => $fileprefix . '_' . $groupletter . '_' . $timestamp . '.tex');
-
+function create_persistent_file($fs, $fileinfo, $content, $path=null) {
     if ($oldfile = $fs->get_file($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'],
             $fileinfo['itemid'], $fileinfo['filepath'], $fileinfo['filename'])) {
         $oldfile->delete();
     }
 
-    $file = $fs->create_file_from_string($fileinfo, $latex);
-
-    return $file;
+    if (isset($content))
+        return $fs->create_file_from_string($fileinfo, $content);
+    else {
+        if (!isset($path)) {
+            throw new coding_exception('no content and no path given');
+        }
+        $file = $fs->create_file_from_pathname($fileinfo, $path);
+        // delete temporary file
+        unlink($path);
+        return $file;
+    }
 }
 
 function offlinequiz_convert_html_to_latex_tagreplace($dom, $tag, $pre, $post) {
@@ -275,7 +360,7 @@ function offlinequiz_convert_html_to_latex_tables($dom) {
 		// TeX needs the number of columns
 		$cmax = 0;
 		foreach ($rows as $row) {
-			$r++ ;
+			$r = 0; // $r++ ; // OSTFALIA: uninitialisierte Variable $r wird inkrementiert
 			foreach (array("td", "th") as $item) {
 				$cols = $row->getElementsByTagName($item);
 				$c = 0;
@@ -304,6 +389,8 @@ function offlinequiz_convert_html_to_latex_single_tag_replace($dom, $pre, $post,
 	$element->appendChild($postNode);
 }
 
+
+
 /**
  * Return the LaTeX representation of a question or answer text.
  * @param string $text
@@ -329,10 +416,11 @@ function offlinequiz_convert_html_to_latex($text) {
 	offlinequiz_convert_html_to_latex_tagreplace($dom, 'ol', '\begin{enumerate}[label=(\arabic*)]', '\end{enumerate}');
 	offlinequiz_convert_html_to_latex_tagreplace($dom, 'ul', '\begin{itemize}', '\end{itemize}');
 	offlinequiz_convert_html_to_latex_tagreplace($dom, 'li', '\item ', '');
-	offlinequiz_convert_html_to_latex_tagreplace($dom, 'br', "\n", ''); // using newline might produce invalid TeX in some cases
+	offlinequiz_convert_html_to_latex_tagreplace($dom, 'br', '\newline ', '');
 	offlinequiz_convert_html_to_latex_tables($dom);
 	offlinequiz_convert_html_to_latex_paragraph($dom);
 	offlinequiz_convert_html_to_latex_span($dom);
+
 	$text = $dom->saveHTML();
 	// replace "$$ ... $$" by "\[ ... \]"
 	$text = preg_replace('/\$\$(.*?)\$\$/s','\[\1\]',$text);
@@ -343,6 +431,54 @@ function offlinequiz_convert_html_to_latex($text) {
 							return $tmp;
 						},
 						$text);
+
+    // handle images
+    while (($startpos = strpos($text, '<img')) !== FALSE) {
+        // find image tag
+        $endpos = strpos($text, '/>', $startpos);
+        if ($endpos) {
+            $imagetext = substr($text, $startpos, $endpos-$startpos+2);
+            $endpos++; // increment for remaining text
+        } else {
+            $endpos = strpos($text, '>', $startpos);
+            $imagetext = substr($text, $startpos, $endpos-$startpos+1).'</img>';
+        }
+        $xmlDoc = new DOMDocument();
+        if (!$xmlDoc->loadXML($imagetext)) {
+            echo 'error parsing image: ' . $imagetext;
+        }
+        $elem = $xmlDoc->getElementsByTagName("img")[0];
+        $imgfile = $elem->getAttribute('src');
+        $width = $elem->getAttribute('width');
+        $height = $elem->getAttribute('height');
+
+        // strip beginning 'file://'
+        if (($filepos = strpos($imgfile, 'file://')) !== FALSE) {
+            $imgfile = substr($imgfile, $filepos + strlen('file://'));
+        } else {
+            echo 'Warning: File ' . $imgfile . ' has no local path!<br>';
+        }
+        //echo $imgfile . ' , width=' . $width . '<br>';
+        $filepos = strrpos($imgfile, '/');
+        //        $imgfile = 'example-image-a'; // substr($imgfile, $filepos + 1);
+
+        $startimage = <<<LATEX
+
+\\begin{figure}[H]
+\\begin{center}
+\\includegraphics[
+LATEX;
+
+        $endimage = <<<LATEX
+}
+\\end{center}
+\\end{figure}
+LATEX;
+
+        $newimagetext = $startimage .  'width=' . $width. 'bp]{' . $imgfile . $endimage;
+        $text = substr($text, 0, $startpos) . $newimagetext . substr($text, $endpos+1);
+    }
+
 	$conversiontable = array(
 		'&Amul;' => 'Ä',
 		'&auml;' => 'ä',
@@ -362,9 +498,123 @@ function offlinequiz_convert_html_to_latex($text) {
 	foreach ($conversiontable as $search => $replace) {
 			$text = str_ireplace($search, $replace, $text);
 	}
+
 	$text = strip_tags($text);
+
+	// strip starting and trailing /newline
+    $len = strlen('\newline');
+    $text = trim($text);
+    while (substr($text, 0, $len) === '\newline') {
+        $text = trim(substr($text, $len));
+    }
+    while (substr($text, strlen($text) - $len) === '\newline') {
+        $text = trim(substr($text, 0, strlen($text) - $len));
+    }
+
+
 	return trim($text);
 }
+
+
+ 
+ 
+ 
+
+
+
+
+
+/*
+function offlinequiz_convert_html_to_latex($text) {
+    $conversiontable = array(
+            'Ä' => '{\"A}',
+            'ä' => '{\"a}',
+            'Ö' => '{\"O}',
+            'ö' => '{\"o}',
+            'Ü' => '{\"U}',
+            'ü' => '{\"u}',
+            'ß' => '{\ss}',
+            '&nbsp;' => ' ',
+            '#' => '\#',
+            '%' => '\%',
+    		'<b>' => '\textbf{',
+    		'</b>' => '}',
+    		'<i>' => '\textit{',
+    		'</i>' => '}',
+    		'<u>' => '\underline{',
+    		'</u>' => '}',
+            '<p>' => ' ',
+            '</p>' => '\newline ',
+            '<br>' => '\newline ',
+            '<br />' => '\newline ',
+            '&gt;' => '>',
+    		'&lt;' => '<',
+        '$$' => '$'
+    );
+
+    $text = strip_tags($text,"<i><b><u><p><br><img>");
+    foreach ($conversiontable as $search => $replace) {
+        $text = str_ireplace($search, $replace, $text);
+    }
+    // handle images
+    while (($startpos = strpos($text, '<img')) !== FALSE) {
+        // find image tag
+        $endpos = strpos($text, '/>', $startpos);
+        if ($endpos) {
+            $imagetext = substr($text, $startpos, $endpos-$startpos+2);
+            $endpos++; // increment for remaining text
+        } else {
+            $endpos = strpos($text, '>', $startpos);
+            $imagetext = substr($text, $startpos, $endpos-$startpos+1).'</img>';
+        }
+        $xmlDoc = new DOMDocument();
+        if (!$xmlDoc->loadXML($imagetext)) {
+            echo 'error parsing image: ' . $imagetext;
+        }
+        $elem = $xmlDoc->getElementsByTagName("img")[0];
+        $imgfile = $elem->getAttribute('src');
+        $width = $elem->getAttribute('width');
+        $height = $elem->getAttribute('height');
+
+        // strip beginning file://
+        if (($filepos = strpos($imgfile, 'file://')) !== FALSE) {
+            $imgfile = substr($imgfile, $filepos + strlen('file://'));
+        } else {
+            echo 'Warning: File ' . $imgfile . ' has no local path!<br>';
+        }
+        echo $imgfile . ' , width=' . $width . '<br>';
+        $filepos = strrpos($imgfile, '/');
+//        $imgfile = 'example-image-a'; // substr($imgfile, $filepos + 1);
+
+        $startimage = <<<LATEX
+
+\\begin{figure}[H]
+\\begin{center}
+\\includegraphics[
+LATEX;
+
+        $endimage = <<<LATEX
+}
+\\end{center}
+\\end{figure}
+LATEX;
+
+        $newimagetext = $startimage .  'width=' . $width. 'bp]{' . $imgfile . $endimage;
+        $text = substr($text, 0, $startpos) . $newimagetext . substr($text, $endpos+1);
+    }
+
+    $len = strlen('\newline');
+    $text = trim($text);
+    while (substr($text, 0, $len) === '\newline') {
+        $text = trim(substr($text, $len));
+    }
+    while (substr($text, strlen($text) - $len) === '\newline') {
+        $text = trim(substr($text, 0, strlen($text) - $len));
+    }
+
+    return $text;
+}
+*/
 
 /**
  * Return the LaTeX representation of an answer.
@@ -373,8 +623,8 @@ function offlinequiz_convert_html_to_latex($text) {
  * @param unknown $answer
  * @return string
  */
-function offlinequiz_get_answer_latex($question, $answer) {
-    $answertext = $question->options->answers[$answer]->answer;
+function offlinequiz_get_answer_latex($question, $answertext, $answer) {
+    //$answertext = $question->options->answers[$answer]->answer;
     $answertext = offlinequiz_convert_html_to_latex($answertext);
     if ($question->options->answers [$answer]->fraction > 0) {
         $result = '\item\answerIs{true} ' . $answertext;
@@ -385,3 +635,4 @@ function offlinequiz_get_answer_latex($question, $answer) {
     $result .= "\n";
     return $result;
 }
+

--- a/pdflib.php
+++ b/pdflib.php
@@ -719,7 +719,7 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
 
             $questiontext = $trans->fix_image_paths ( $questiontext, $question->contextid, 'questiontext', $question->id, 1, 300, $offlinequiz->disableimgnewlines );
 
-            $html = '';
+            $html = '<ol type="1" style = "padding-left: 0"><li value ="' . $number .'">';
 
             $html .= $questiontext . '<br/><br/>';
             if ($question->qtype == 'multichoice' || $question->qtype == 'multichoiceset') {
@@ -731,6 +731,8 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
                 $attempt = $templateusage->get_question_attempt ( $slot );
                 $order = $slotquestion->get_order ( $attempt ); // Order of the answers.
 
+
+                $html .= '<ol type="a">';
                 foreach ($order as $key => $answer) {
                     $answertext = $question->options->answers[$answer]->answer;
                     // Filter only for tex formulas.
@@ -755,16 +757,17 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
                         $answertext .= " (" . round ( $question->options->answers[$answer]->fraction * 100 ) . "%)";
                     }
 
-                    $html .= number_in_style ( $key, $question->options->answernumbering ) . ') &nbsp; ';
-                    $html .= $answertext;
+                    //$html .= number_in_style ( $key, $question->options->answernumbering ) . ') &nbsp; ';
+                    $html .= '<li>' .$answertext . '</li>';
 
                     if ($correction) {
                         if ($question->options->answers[$answer]->fraction > 0) {
                             $html .= '</b>';
                         }
                     }
-                    $html .= "<br/>\n";
+                    //$html .= "<br/>\n";
                 }
+                $html .= '</ol>';
 
                 $infostring = offlinequiz_get_question_infostring($offlinequiz, $question);
                 if ($infostring) {
@@ -772,10 +775,17 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
                 }
             }
 
+            $style = '<style>' .
+            'ol {'.
+                    'padding-left: 18px;'.
+            '}'.
+            '</style>';
+
+            $html .= '</li></ol>';
             // Finally print the question number and the HTML string.
             if ($question->qtype == 'multichoice' || $question->qtype == 'multichoiceset') {
-                $pdf->SetFont ( 'FreeSans', 'B', $offlinequiz->fontsize );
-                $pdf->Cell ( 4, round ( $offlinequiz->fontsize / 2 ), "$number)  ", 0, 0, 'R' );
+                //$pdf->SetFont ( 'FreeSans', 'B', $offlinequiz->fontsize );
+                //$pdf->Cell ( 4, round ( $offlinequiz->fontsize / 2 ), "$number)  ", 0, 0, 'R' );
                 $pdf->SetFont ( 'FreeSans', '', $offlinequiz->fontsize );
             }
 
@@ -786,7 +796,9 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
                 $html = preg_replace("/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/ms", "", $html);
             }
 
-            $pdf->writeHTMLCell ( 165, round ( $offlinequiz->fontsize / 2 ), $pdf->GetX (), $pdf->GetY () + 0.3, $html );
+            $pdf->writeHTMLCell ( 165, round ( $offlinequiz->fontsize / 2 ), $pdf->GetX (), $pdf->GetY () + 0.3, $html);
+                    // 0,0, false, true, 'LRTB'); // karins versuch
+
             $pdf->Ln ();
 
             if ($pdf->is_overflowing ()) {
@@ -796,8 +808,8 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
 
                 // Print the question number and the HTML string again on the new page.
                 if ($question->qtype == 'multichoice' || $question->qtype == 'multichoiceset') {
-                    $pdf->SetFont ( 'FreeSans', 'B', $offlinequiz->fontsize );
-                    $pdf->Cell ( 4, round ( $offlinequiz->fontsize / 2 ), "$number)  ", 0, 0, 'R' );
+                    //$pdf->SetFont ( 'FreeSans', 'B', $offlinequiz->fontsize );
+                    //$pdf->Cell ( 4, round ( $offlinequiz->fontsize / 2 ), "$number)  ", 0, 0, 'R' );
                     $pdf->SetFont ( 'FreeSans', '', $offlinequiz->fontsize );
                 }
 

--- a/report/rimport/errorpages_table.php
+++ b/report/rimport/errorpages_table.php
@@ -52,13 +52,9 @@ class offlinequiz_selectall_table extends flexible_table {
 
         echo '<div id="tablecontainer" class="centerbox">';
         echo '<form id="reportform" method="post" action="'. $this->reportscript .
-             '" onsubmit="return confirm(\'' . $this->params['strreallydel'] . '\');">';
-        echo ' <div>';
+             '" ;">';
+        // '" onsubmit="return confirm(\'' . $this->params['strreallydel'] . '\');">';
 
-        foreach ($this->params as $name => $value) {
-            echo '<input type="hidden" name="' . $name .'" value="' . $value . '" />';
-        }
-        echo '<input type="hidden" name="sesskey" value="' . sesskey() . '" />';
         echo '  <center>';
     }
 
@@ -71,11 +67,58 @@ class offlinequiz_selectall_table extends flexible_table {
         echo '<a href="#" class="selectall">'. $strselectall . '</a> / ';
         echo '<a href="#" class="deselectall">' . $strselectnone . '</a> ';
         echo '&nbsp;&nbsp;';
-        echo '<input type="submit" value="'.get_string('deleteselectedpages', 'offlinequiz_rimport').'" class="btn btn-secondary"/>';
+
+        // delete
+        echo ' <div>';
+            foreach ($this->params as $name => $value) {
+                if ($name != 'action' && $name != 'strreallydel') {
+                    echo '<input type="hidden" name="' . $name . '" value="' . $value . '" />';
+                }
+            }
+            echo '<input type="hidden" name="sesskey" value="' . sesskey() . '" />';
+
+            //echo '<input type="submit" value="'.get_string('deleteselectedpages', 'offlinequiz_rimport').'" class="btn btn-secondary"/>';
+            $onclick = 'onclick= "return confirm(\''. $this->params['strreallydel'] .'\')"';
+            echo '<button type="submit" ' . $onclick . ' name="action" value="delete">'.get_string('deleteselectedpages', 'offlinequiz_rimport').'</button>';
+
+        echo ' </div>';
+
+        // insert dummies
+        echo ' <div>';
+            foreach ($this->params as $name => $value) {
+                if ($name != 'action' && $name != 'strreallydel') {
+                    echo '<input type="hidden" name="' . $name .'" value="' . $value . '" />';
+                }
+            }
+            //echo '<input type="hidden" name="action" value="insert_dummies" />';
+            echo '<input type="hidden" name="strreallydel" value="">';
+
+            echo '<input type="hidden" name="sesskey" value="' . sesskey() . '" />';
+            $onclick = 'onclick= "return confirm(\''. get_string('reallyinsertdummies', 'offlinequiz_rimport').'\')"';
+            //echo '<input type="submit" value="'.get_string('importusers', 'offlinequiz_rimport').'" class="btn btn-secondary"/>';
+            echo '<button type="submit" ' . $onclick . ' name="action" value="insert_dummies">'.get_string('importusers', 'offlinequiz_rimport').'</button>';
+        echo ' </div>';
+
+        // rescan and assign results
+/*
+        echo ' <div>';
+            foreach ($this->params as $name => $value) {
+                if ($name != 'action' && $name != 'strreallydel') {
+                    echo '<input type="hidden" name="' . $name .'" value="' . $value . '" />';
+                }
+            }
+            //echo '<input type="hidden" name="action" value="rescan" />';
+            echo '<input type="hidden" name="strreallydel" value="wollen Sie die Seiten wirklich nochmals scannen?">';
+
+            echo '<input type="hidden" name="sesskey" value="' . sesskey() . '" />';
+            //echo '<input type="submit" value="'.get_string('rescanpages', 'offlinequiz_rimport').'" class="btn btn-secondary"/>';
+            echo '<button type="submit" name="action" value="rescan">'.get_string('rescanpages', 'offlinequiz_rimport').'</button>';
+        echo ' </div>';
+*/
         echo '</td></tr></table>';
         echo '  </center>';
+
         // Close form.
-        echo ' </div>';
         echo '</form></div>';
     }
 } // End class.

--- a/report/rimport/lang/de/offlinequiz_rimport.php
+++ b/report/rimport/lang/de/offlinequiz_rimport.php
@@ -66,3 +66,8 @@ $string['showpage'] = 'Seite anzeigen';
 $string['username'] = 'Benutzername';
 $string['waitingforanalysis'] = 'Wartet auf Auswertung';
 $string['ziporimagefile'] = 'ZIP- oder Bild-Datei';
+
+$string['importusers'] = 'Teilnehmer als Dummies einfügen';
+$string['rescanpages'] = 'Seiten neu scannen';
+$string['reallyinsertdummies'] = 'Möchten Sie die ausgewählten Teilnehmer wirklich in Moodle als Dummies einfügen?';
+

--- a/report/rimport/lang/en/offlinequiz_rimport.php
+++ b/report/rimport/lang/en/offlinequiz_rimport.php
@@ -66,3 +66,10 @@ $string['showpage'] = 'Show';
 $string['username'] = 'Username';
 $string['waitingforanalysis'] = 'Waiting for Analysis';
 $string['ziporimagefile'] = 'ZIP- or image-file';
+
+
+$string['importusers'] = 'insert users as dummies';
+$string['rescanpages'] = 'rescan pages';
+$string['reallyinsertdummies'] = 'Do you really want to insert new dummy users?';
+
+

--- a/report/rimport/report.php
+++ b/report/rimport/report.php
@@ -297,9 +297,10 @@ class offlinequiz_rimport_report extends offlinequiz_default_report {
             $action = optional_param('action', '', PARAM_ACTION);
 
             switch ($action) {
+                case 'rescan':
+                case 'insert_dummies':
                 case 'delete':
                     if (confirm_sesskey()) {
-
                         $selectedpageids = array();
                         $params = (array) data_submitted();
 
@@ -311,7 +312,20 @@ class offlinequiz_rimport_report extends offlinequiz_default_report {
 
                         foreach ($selectedpageids as $pageid) {
                             if ($pageid && ($page = $DB->get_record('offlinequiz_scanned_pages', array('id' => $pageid)))) {
-                                offlinequiz_delete_scanned_page($page, $this->context);
+                                switch($action) {
+                                    case 'rescan':
+                                        echo 'rescan all selected pages';
+                                        offlinequiz_update_page_after_dummy_enrolment($page, $this->context);
+                                        break;
+                                    case 'insert_dummies':
+                                        echo 'we will insert some dummies';
+                                        offlinequiz_insert_dummy($page, $this->context);
+                                        break;
+                                    case 'delete':
+                                        echo 'delete pages';
+                                        offlinequiz_delete_scanned_page($page, $this->context);
+                                        break;
+                                }
                             }
                         }
 

--- a/settings.php
+++ b/settings.php
@@ -68,6 +68,14 @@ if ($ADMIN->fulltree) {
     		get_string('disableimgnewlines', 'offlinequiz'), get_string('configdisableimgnewlines', 'offlinequiz'),
     		0));
 
+
+
+    // OSTFALIA
+    // path to pdflatex
+    $settings->add(new admin_setting_configtext('offlinequiz/pathpdflatex', get_string('pathpdflatex', 'offlinequiz'),
+            get_string('pathpdflatex_help', 'offlinequiz'), '/usr/bin/pdflatex'));
+
+
     // Review options.
     $settings->add(new admin_setting_heading('reviewheading',
             get_string('reviewoptionsheading', 'offlinequiz'), ''));

--- a/tests/behat/offlinequiz_createforms.feature
+++ b/tests/behat/offlinequiz_createforms.feature
@@ -7,7 +7,7 @@ Feature: Within a moodle instance, a teacher should be able to create all forms 
   @ javascript
   Scenario: Login as a teacher, add a new grouptool to a course and there some multiple choice questions. Then create the forms for the offline quiz.
     Given the following "users" exist:
-      | username | firstname | lastname | email
+      | username | firstname | lastname | email |
       | teacher1 | Teacher | 1 | teacher1@example.com |
     And the following "courses" exist:
       | fullname | shortname | category | groupmode |

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2018011602;
+$plugin->version   = 2018071201;
 $plugin->requires  = 2017111300;
 $plugin->component = 'mod_offlinequiz';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = "v3.4.2";
+$plugin->release   = "v3.4.2 Ostfalia";


### PR DESCRIPTION
Hallo, 
ich habe im Frühjahr 2018 einige Anpassungen für unsere Mathematik-Vortests gemacht, die ich hier einfach mal zur Verfügung stellen möchte. 
Randbedingungen bei uns sind:
1. die Nutzer sind zum Zeitpunkt des Tests noch nicht im System 
2. die Tests erfordern viele mathematische Formeln (LaTeX)

Zu 1. hatte ich eine Erweiterung gemacht, die es erlaubt, die nicht im System befindlichen Nutzer automatisch (durch Drücken eines Buttons) in das System aufzunehmen und in den etsprechenden Kurs einzuschreiben. Diese Lösung wurde bei uns allerdings am Ende doch nicht genutzt, da die Verantwortlichen lieber vorab eine CSV-Datei mit Dummy-Nutzerdaten erzeugen, die sie vorab ins System laden. 
Zu 2. Da die Fragen in hohem Ausmaß mathematische Formeln einsetzen, war die Ausgabe in pdf und winword unbefriedigend. Ich habe da an vielen Stellschrauben gedreht, aber so richtig zufrieden waren wir nicht. Die Formeln werden in Bilder umgewandelt, die entweder von der Größe oder vom vertikalen Alignment nicht passten. Latex ist dafür besser geeignet. Die Unterstützung steckte aber noch in den Kinderschuhen. Vor allem das Nutzen von Bildern war hier gar nicht möglich. Da man in Latex-Dateien keine Bilder einbetten kann und das Auslesen der Bilder auf dem Client auch kaum möglich ist, erzeuge ich nun bereits auf dem Server aus der Tex-Datei und den Bildern eine fertige pdf-Datei mit pdflatex. Das Handling wird dadruch für den Anwender auch angenehmer, da er die Umwandlung der Tex-Datei in ein ausdruckbares Dokument nicht mehr selbst vornehmen muss. Das erledigt der Moodle-Server gleich mit. 

Viele Grüße 