### PR TITLE
Add questions instructions version 2

### DIFF
--- a/createquiz.php
+++ b/createquiz.php
@@ -270,7 +270,7 @@ if ($mode == 'preview') {
                 $question = $questions[$slotquestion->id];
                 $attempt = $templateusage->get_question_attempt($slot);
                 $order = $slotquestion->get_order($attempt);  // Order.
-                offlinequiz_print_question_preview($question, $order, $questionnumber, $context, $PAGE);
+                offlinequiz_print_question_preview($question, $order, $questionnumber, $context, $PAGE, $offlinequiz);
                 // Note: we don't have description questions in quba slots.
                 $questionnumber++;
             }
@@ -290,7 +290,7 @@ if ($mode == 'preview') {
                     $order = $slotquestion->get_order($attempt);
                 }
                 // Use our own function to print the preview.
-                offlinequiz_print_question_preview($question, $order, $questionnumber, $context, $PAGE);
+                offlinequiz_print_question_preview($question, $order, $questionnumber, $context, $PAGE, $offlinequiz);
                 if ($question->qtype != 'description') {
                     $questionnumber++;
                 }

--- a/documentlib.php
+++ b/documentlib.php
@@ -28,7 +28,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 function offlinequiz_get_question_infostring($offlinequiz, $question) {
-    if ($offlinequiz->showgrades || $offlinequiz->showquestioninfo) {
+    if ($offlinequiz->showgrades || $offlinequiz->showquestioninfo == OFFLINEQUIZ_QUESTIONINFO_QTYPE
+        || $offlinequiz->showquestioninfo == OFFLINEQUIZ_QUESTIONINFO_ANSWERS) {
         $infostr = '(';
         $questioninfo = offlinequiz_get_questioninfo($offlinequiz, $question);
         if ($questioninfo) {
@@ -88,4 +89,17 @@ function offlinequiz_get_amount_correct_answers($question) {
         }
     }
     return $amount;
+}
+
+function offlinequiz_get_answerprompt($offlinequiz, $question) {
+    if ($offlinequiz->showquestioninfo == OFFLINEQUIZ_QUESTIONINFO_PROMPT) {
+        if ($question->qtype == 'multichoice' && $question->options->single) {
+            $answerprompt = get_string('selectone', 'qtype_multichoice');
+        } elseif ($question->qtype !== 'description') {
+            $answerprompt = get_string('selectmulti', 'qtype_multichoice');
+        }
+        return $answerprompt;
+    } else {
+        return null;
+    }
 }

--- a/docxlib.php
+++ b/docxlib.php
@@ -552,6 +552,10 @@ function offlinequiz_create_docx_question(question_usage_by_activity $templateus
             // Either we print the question HTML.
             $questiontext = $question->questiontext;
 
+            if ($question->qtype !== 'description') {
+                $questiontext .= offlinequiz_get_answerprompt ($offlinequiz, $question);
+            }
+
             // Filter only for tex formulas.
             if (!empty($texfilter)) {
                 $questiontext = $texfilter->filter($questiontext);
@@ -640,6 +644,10 @@ function offlinequiz_create_docx_question(question_usage_by_activity $templateus
 
             // Print the question.
             $questiontext = $question->questiontext;
+
+            if ($question->qtype !== 'description') {
+                $questiontext .= offlinequiz_get_answerprompt ($offlinequiz, $question);
+            }
 
             // Filter only for tex formulas.
             if (!empty($texfilter)) {

--- a/lang/en/offlinequiz.php
+++ b/lang/en/offlinequiz.php
@@ -561,6 +561,7 @@ $string['questionanalysistitle'] = 'Difficulty Analysis Table';
 $string['questionbankcontents'] = 'Question bank contents';
 $string['questionforms'] = 'Question forms';
 $string['questioninfoanswers'] = 'Number of correct answers';
+$string['questioninfoprompt'] = 'Answer prompt';
 $string['questioninfocorrectanswer'] = 'correct answer';
 $string['questioninfocorrectanswers'] = 'correct answers';
 $string['questioninfonone'] = 'Nothing';
@@ -765,6 +766,7 @@ You can choose one of these:
 <li> Nothing
 <li> Question type - Depending on question type Single-Choice, Multiple-Choice, All-or-Nothing Multiple-Choice will be printed
 <li> Number of correct answers - The number of correct answers will be printed
+<li> Answer prompt - Depending on question type "Select one:" or "Select one or more:" will be printed
 </ul>';
 $string['showstudentview'] = 'Show student view';
 $string['showtutorial'] = 'Show an offline quiz tutorial to students.';

--- a/latexlib.php
+++ b/latexlib.php
@@ -98,7 +98,12 @@ function offlinequiz_create_latex_question(question_usage_by_activity $templateu
 
             $question = $questions[$currentquestionid];
 
-            $questiontext = offlinequiz_convert_html_to_latex($question->questiontext);
+            $questiontext = $question->questiontext;
+            if ($question->qtype !== 'description') {
+                $questiontext .= offlinequiz_get_answerprompt ($offlinequiz, $question);
+            }
+
+            $questiontext = offlinequiz_convert_html_to_latex($questiontext);
 
             $latexforquestions .= '\item ' .  $questiontext . "\n";
 
@@ -137,7 +142,11 @@ function offlinequiz_create_latex_question(question_usage_by_activity $templateu
             $currentquestionid = $question->id;
 
             $questiontext = $question->questiontext;
-            $questiontext = offlinequiz_convert_html_to_latex($question->questiontext);
+            if ($question->qtype !== 'description') {
+                $questiontext .= offlinequiz_get_answerprompt ($offlinequiz, $question);
+            }
+
+            $questiontext = offlinequiz_convert_html_to_latex($questiontext);
             if ($question->qtype == 'description') {
                 $latexforquestions .= "\n" . '\\ ' . $questiontext . "\n";
             } else {

--- a/locallib.php
+++ b/locallib.php
@@ -1514,6 +1514,12 @@ function offlinequiz_print_question_preview($question, $choiceorder, $number, $c
     $text = question_rewrite_question_preview_urls($question->questiontext, $question->id,
             $question->contextid, 'question', 'questiontext', $question->id,
             $context->id, 'offlinequiz');
+    // JR
+    if ($question->qtype == 'multichoice' && $question->options->single) {
+        $text .= get_string('selectone', 'qtype_multichoice');
+    } else {
+        $text .= get_string('selectmulti', 'qtype_multichoice');
+    }
 
     // Remove leading paragraph tags because the cause a line break after the question number.
     $text = preg_replace('!^<p>!i', '', $text);

--- a/locallib.php
+++ b/locallib.php
@@ -70,6 +70,7 @@ define('OFFLINEQUIZ_LATEX_FORMAT', 2);  // LATEX file format for question sheets
 define('OFFLINEQUIZ_QUESTIONINFO_NONE', 0); // No info is printed.
 define('OFFLINEQUIZ_QUESTIONINFO_QTYPE', 1); // The question type is printed.
 define('OFFLINEQUIZ_QUESTIONINFO_ANSWERS', 2); // The number of correct answers is printed.
+define('OFFLINEQUIZ_QUESTIONINFO_PROMPT', 3); // The question prompt is printed.
 
 define('NUMBERS_PER_PAGE', 30);        // Number of students on participants list.
 define('OQ_IMAGE_WIDTH', 860);         // Width of correction form.
@@ -1495,7 +1496,7 @@ function offlinequiz_delete_template_usages($offlinequiz, $deletefiles = true) {
  * @param int $number
  * @param object $context
  */
-function offlinequiz_print_question_preview($question, $choiceorder, $number, $context, $page) {
+function offlinequiz_print_question_preview($question, $choiceorder, $number, $context, $page, $offlinequiz) {
     global $CFG, $DB;
 
     require_once($CFG->dirroot . '/filter/mathjaxloader/filter.php' );
@@ -1514,13 +1515,13 @@ function offlinequiz_print_question_preview($question, $choiceorder, $number, $c
     $text = question_rewrite_question_preview_urls($question->questiontext, $question->id,
             $question->contextid, 'question', 'questiontext', $question->id,
             $context->id, 'offlinequiz');
-    // JR
-    if ($question->qtype == 'multichoice' && $question->options->single) {
-        $text .= get_string('selectone', 'qtype_multichoice');
-    } else {
-        $text .= get_string('selectmulti', 'qtype_multichoice');
+    if ($offlinequiz->showquestioninfo == OFFLINEQUIZ_QUESTIONINFO_PROMPT) {
+      if ($question->qtype == 'multichoice' && $question->options->single) {
+          $text .= get_string('selectone', 'qtype_multichoice');
+      } else {
+          $text .= get_string('selectmulti', 'qtype_multichoice');
+      }
     }
-
     // Remove leading paragraph tags because the cause a line break after the question number.
     $text = preg_replace('!^<p>!i', '', $text);
 
@@ -1578,7 +1579,8 @@ function offlinequiz_print_question_preview($question, $choiceorder, $number, $c
             echo "</div>";
         }
     }
-    echo "</div>";
+    $txt = offlinequiz_get_question_infostring($offlinequiz, $question);
+    echo $txt. "</div>";
 }
 
 /**

--- a/mod_form.php
+++ b/mod_form.php
@@ -186,6 +186,7 @@ class mod_offlinequiz_mod_form extends moodleform_mod {
         $options[OFFLINEQUIZ_QUESTIONINFO_NONE] = get_string("questioninfonone", "offlinequiz");
         $options[OFFLINEQUIZ_QUESTIONINFO_QTYPE] = get_string("questioninfoqtype", "offlinequiz");
         $options[OFFLINEQUIZ_QUESTIONINFO_ANSWERS] = get_string("questioninfoanswers", "offlinequiz");
+        $options[OFFLINEQUIZ_QUESTIONINFO_PROMPT] = get_string("questioninfoprompt", "offlinequiz");
         $mform->addElement('select', 'showquestioninfo', get_string("showquestioninfo", "offlinequiz"), $options, $attribs);
         $mform->addHelpButton('showquestioninfo', "showquestioninfo", "offlinequiz");
 

--- a/pdflib.php
+++ b/pdflib.php
@@ -563,11 +563,9 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
             $pdf->checkpoint();
 
             $questiontext = $question->questiontext;
-            // JR
-            if ($question->qtype == 'multichoice' && $question->options->single) {
-                $questiontext .= get_string('selectone', 'qtype_multichoice');
-            } elseif ($question->qtype !== 'description') {
-                $questiontext .= get_string('selectmulti', 'qtype_multichoice');
+
+            if ($question->qtype !== 'description') {
+                $questiontext .= offlinequiz_get_answerprompt ($offlinequiz, $question);
             }
 
             // Filter only for tex formulas.
@@ -707,11 +705,8 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
             $pdf->checkpoint();
 
             $questiontext = $question->questiontext;
-            // JR
-            if ($question->qtype == 'multichoice' && $question->options->single) {
-                $questiontext .= get_string('selectone', 'qtype_multichoice');
-            } elseif ($question->qtype !== 'description') {
-                $questiontext .= get_string('selectmulti', 'qtype_multichoice');
+            if ($question->qtype !== 'description') {
+                $questiontext .= offlinequiz_get_answerprompt ($offlinequiz, $question);
             }
 
             // Filter only for tex formulas.

--- a/pdflib.php
+++ b/pdflib.php
@@ -563,6 +563,12 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
             $pdf->checkpoint();
 
             $questiontext = $question->questiontext;
+            // JR
+            if ($question->qtype == 'multichoice' && $question->options->single) {
+                $questiontext .= get_string('selectone', 'qtype_multichoice');
+            } elseif ($question->qtype !== 'description') {
+                $questiontext .= get_string('selectmulti', 'qtype_multichoice');
+            }
 
             // Filter only for tex formulas.
             if (!empty($texfilter)) {
@@ -701,6 +707,12 @@ function offlinequiz_create_pdf_question(question_usage_by_activity $templateusa
             $pdf->checkpoint();
 
             $questiontext = $question->questiontext;
+            // JR
+            if ($question->qtype == 'multichoice' && $question->options->single) {
+                $questiontext .= get_string('selectone', 'qtype_multichoice');
+            } elseif ($question->qtype !== 'description') {
+                $questiontext .= get_string('selectmulti', 'qtype_multichoice');
+            }
 
             // Filter only for tex formulas.
             if (! empty ( $texfilter )) {


### PR DESCRIPTION
Please consider this new version of my previous PR.
* add extra option "Answer prompt" to "Print info about answers" Form settings
* depending on question type "Select one:" or "Select one or more:" will be printed between the question text and the list of answers
* the various "info about answers" are now also printed on the "Preview for forms" page, to make it more similar to the actual printed questions form