### PR TITLE
3.10 add missing quotation marks around database field name

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -276,7 +276,7 @@ class provider implements
                 SELECT sp.offlinequizid id
                 FROM {offlinequiz_scanned_pages} sp";
         if ($type == "int") {
-            $sql  .= " JOIN {user} u ON u." . $offlinequizconfig->ID_field . " = " . $DB->sql_cast_char2int(sp.userkey);
+            $sql  .= " JOIN {user} u ON u." . $offlinequizconfig->ID_field . " = " . $DB->sql_cast_char2int("sp.userkey");
         } else {
             $sql .= " JOIN {user} u ON u." . $offlinequizconfig->ID_field . " = sp.userkey";
         }
@@ -333,7 +333,7 @@ class provider implements
                 SELECT sp.offlinequizid id
                 FROM {offlinequiz_scanned_pages} sp";
         if ($type == "int") {
-            $sql  .= " JOIN {user} u ON u." . $offlinequizconfig->ID_field . " = " . $DB->sql_cast_char2int(sp.userkey);
+            $sql  .= " JOIN {user} u ON u." . $offlinequizconfig->ID_field . " = " . $DB->sql_cast_char2int("sp.userkey");
         } else {
             $sql .= " JOIN {user} u ON u." . $offlinequizconfig->ID_field . " = sp.userkey";
         }


### PR DESCRIPTION
Due to missing quotation marks around the sp.userkey database field name in
\mod_offlinequiz\privacy\provider::get_contexts_for_userid(int $userid) the
job gets started again and again and floods administrators (or GDPR officers)
with mails stating the process failed.

The same typo was also found (and fixed) in method export_user_data!