### PR TITLE
Added webservice-functions to mod_offlinequiz

### DIFF
--- a/db/services.php
+++ b/db/services.php
@@ -1,0 +1,33 @@
+<?php
+
+$functions = [
+
+    'mod_offlinequiz_get_offlinequizzes_by_courses' => [
+        'classname'     => 'mod_offlinequiz_external',
+        'methodname'    => 'get_offlinequizzes_by_courses',
+        'classpath'     => 'mod/offlinequiz/externallib.php',
+        'description'   => 'Get all offlinequizzes in the given courses',
+        'type'          => 'read',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+    ],
+
+    'mod_offlinequiz_get_offlinequiz' => [
+        'classname'     => 'mod_offlinequiz_external',
+        'methodname'    => 'get_offlinequiz',
+        'classpath'     => 'mod/offlinequiz/externallib.php',
+        'description'   => 'Get offlinequizze with the given id',
+        'type'          => 'read',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+    ],
+
+    'mod_offlinequiz_get_attempt_review' => [
+        'classname'     => 'mod_offlinequiz_external',
+        'methodname'    => 'get_attempt_review',
+        'classpath'     => 'mod/offlinequiz/externallib.php',
+        'description'   => "Get current user's review for the specified offlinequiz.",
+        'type'          => 'read',
+        'capabilities'  => 'mod/offlinequiz:view',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+    ],
+
+];

--- a/externallib.php
+++ b/externallib.php
@@ -1,0 +1,378 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die;
+
+require_once("$CFG->libdir/externallib.php");
+require_once("$CFG->dirroot/user/externallib.php");
+require_once($CFG->dirroot . '/mod/offlinequiz/locallib.php');
+require_once($CFG->dirroot . '/mod/offlinequiz/lib.php');
+
+require_once($CFG->dirroot . '/mod/quiz/attemptlib.php');
+
+
+class mod_offlinequiz_external extends external_api
+{
+    /**
+     * Get definition of the parameters for the get_offlinequizzes_by_courses function
+     *
+     * @return external_function_parameters
+     */
+    public static function get_offlinequizzes_by_courses_parameters() {
+        return new external_function_parameters(
+            [
+                'courseids' => new external_multiple_structure(
+                    new external_value(PARAM_INT, 'Course id'), 'Array of course ids (all enrolled courses if empty array)', VALUE_DEFAULT, []
+                ),
+            ]
+        );
+    }
+
+    /**
+     * Get definition of the return value of the get_offlinequizzes_by_courses function
+     *
+     * @return external_single_structure
+     */
+    public static function get_offlinequizzes_by_courses_returns() {
+        return new external_single_structure(
+            [
+                'offlinequizzes' => new external_multiple_structure(self::offlinequiz_structure(), 'offlinequiz object'),
+                'warnings' => new external_warnings('warnings')
+            ]
+        );
+    }
+
+    /** Gets information on offlinequizzes in the provided courses (all courses if no ids are provided).
+     *
+     * @param $courseids
+     * @return stdClass
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     */
+    public static function get_offlinequizzes_by_courses($courseids) {
+        $warnings = [];
+
+        $params = self::validate_parameters(self::get_offlinequizzes_by_courses_parameters(), [
+            'courseids' => $courseids,
+        ]);
+
+        $mycourses = [];
+        if (empty($params['courseids'])) {
+            $mycourses = enrol_get_my_courses();
+            $params['courseids'] = array_keys($mycourses);
+        }
+        $returnedquizzes = [];
+        // Ensure there are courseids to loop through.
+        if (!empty($params['courseids'])) {
+
+            list($courses, $warnings) = external_util::validate_courses($params['courseids'], $mycourses);
+
+            $offlinequiz_instances = get_all_instances_in_courses("offlinequiz", $courses);
+            foreach ($offlinequiz_instances as $offlinequiz_instance) {
+                $context = context_module::instance($offlinequiz_instance->coursemodule);
+                $offlinequiz = self::get_offlinequiz_record($offlinequiz_instance->id);
+                $returnedquizzes[] = self::export_offlinequiz($offlinequiz, $context);
+            }
+        }
+        $result = new stdClass();
+        $result->offlinequizzes = $returnedquizzes;
+        $result->warnings = $warnings;
+        return $result;
+    }
+
+    /**
+     * Get definition of the parameters for the get_offlinequiz function
+     *
+     * @return external_function_parameters
+     */
+    public static function get_offlinequiz_parameters() {
+        return new external_function_parameters(
+            [
+                'offlinequizid' => new external_value(PARAM_INT, 'offlinequiz id'),
+            ]
+        );
+    }
+
+    /**
+     * Get definition of the return value of the get_offlinequiz function
+     *
+     * @return external_single_structure
+     */
+    public static function get_offlinequiz_returns() {
+        return new external_single_structure(
+            [
+                'offlinequiz' => self::offlinequiz_structure(),
+            ]
+        );
+    }
+
+    /** Gets information on offlinequizzes in the provided courses (all courses if no ids are provided).
+     *
+     * @param $courseids
+     * @return stdClass
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     */
+    public static function get_offlinequiz($offlinequizid) {
+        $warnings = [];
+
+        $params = self::validate_parameters(self::get_offlinequiz_parameters(), [
+            'offlinequizid' => $offlinequizid,
+        ]);
+
+        $cm = get_coursemodule_from_instance('offlinequiz', $params['offlinequizid'], 0, false, MUST_EXIST);
+
+        $context = context_module::instance($cm->id);
+        self::validate_context($context);
+
+        $result = new stdClass();
+        $result->offlinequiz = self::export_offlinequiz(self::get_offlinequiz_record($cm->instance), $context);
+        $result->warnings = $warnings;
+        return $result;
+    }
+
+    /**
+     * Get definition of the parameters for the get_attempt_review function
+     *
+     * @return external_function_parameters
+     */
+    public static function get_attempt_review_parameters() {
+        return new external_function_parameters(
+            [
+                'offlinequizid' => new external_value(PARAM_INT, 'offlinequiz id'),
+            ]
+        );
+    }
+
+    /**
+     * Get definition of the return value of the get_attempt_review function
+     *
+     * @return external_single_structure
+     */
+    public static function get_attempt_review_returns() {
+        return new external_single_structure(
+            [
+                'offlinequiz' => self::offlinequiz_structure(),
+                'grade' => new external_value(PARAM_RAW, 'grade for the quiz (or empty or "notyetgraded")', VALUE_OPTIONAL),
+                'maxgrade' => new external_value(PARAM_RAW, 'maxgrade for the quiz ', VALUE_OPTIONAL),
+                'rawgrade' => new external_value(PARAM_RAW, 'grade for the quiz (or empty or "notyetgraded")', VALUE_OPTIONAL),
+                'rawmaxgrade' => new external_value(PARAM_RAW, 'grade for the quiz (or empty or "notyetgraded")', VALUE_OPTIONAL),
+                'questions' => new external_multiple_structure(self::question_structure(), 'question object'),
+            ]
+        );
+    }
+
+    /**
+     * Gets the current user's review for the offlinequiz with the specified id.
+     *
+     * @param $offlinequizid
+     * @return stdClass
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     */
+    public static function get_attempt_review($offlinequizid) {
+        global $USER;
+
+        $res = new stdClass();
+        $params = self::validate_parameters(self::get_attempt_review_parameters(), [
+            'offlinequizid' => $offlinequizid
+        ]);
+
+        $offlinequiz = self::get_offlinequiz_record($params['offlinequizid']);
+        if (!$cm = get_coursemodule_from_instance("offlinequiz", $offlinequiz->id, $offlinequiz->course)) {
+            print_error("The course module for the offlinequiz with id $offlinequiz->id is missing");
+        }
+        $context = context_module::instance($cm->id);
+        if ($results = offlinequiz_get_user_results($offlinequiz->id, $USER->id)
+            and offlinequiz_results_open($offlinequiz)) {
+            //there should be only one result
+            if (count($results) > 1) {
+                print_error("More than one result is found for user.");
+            }
+            foreach ($results as $id => $result) {
+                $options = offlinequiz_get_review_options($offlinequiz, $result, $context);
+                $group = self::get_group($result->offlinegroupid);
+                if (!$quba = question_engine::load_questions_usage_by_activity($result->usageid)) {
+                    print_error("question usage with id $result->usageid not found");
+                }
+                $res->offlinequiz = self::export_offlinequiz($offlinequiz, $context);
+
+                if ($options->marks > 0) {
+                    $res->maxgrade = $offlinequiz->grade;
+                    $res->rawmaxgrade = $group->sumgrades;
+                }
+                if ($options->marks > 1) {
+                    $res->grade = offlinequiz_rescale_grade($result->sumgrades, $offlinequiz, $group, false);
+                    $res->rawgrade = $result->sumgrades;
+                }
+                $res->questions = self::get_attempt_questions_data($quba, $options);
+            }
+        } else {
+            print_error("Review currently inaccessible.");
+        }
+
+        return $res;
+    }
+
+    /**
+     * Gets information on each question of attempt.
+     *
+     * @param question_usage_by_activity $quba
+     * @param $displayoptions
+     * @return array
+     */
+    private static function get_attempt_questions_data(question_usage_by_activity $quba, $displayoptions) {
+        $questions = [];
+        $slots = $quba->get_slots();
+        $number = 1;
+        foreach ($slots as $id => $slot) {
+            $qattempt = $quba->get_question_attempt($slot);
+            $questiondef = $qattempt->get_question(true);
+            $qtype = $questiondef->get_type_name();
+
+
+            $question = [
+                'slot' => $slot,
+                'type' => $qtype,
+                'sequencecheck' => $qattempt->get_sequence_check_count(),
+                'lastactiontime' => $qattempt->get_last_step()->get_timecreated(),
+                'hasautosavedstep' => $qattempt->has_autosaved_step(),
+                'settings' => !empty($settings) ? json_encode($settings) : null,
+            ];
+
+            if ($questiondef->length) {
+                $question['number'] = $number;
+                $number += $questiondef->length;
+                $showcorrectness = $displayoptions->correctness && $qattempt->has_marks();
+                if ($showcorrectness) {
+                    $question['state'] = (string)$quba->get_question_state($slot);
+                }
+                $question['status'] = $quba->get_question_state_string($slot, $displayoptions->correctness);
+            }
+            if ($displayoptions->marks >= question_display_options::MAX_ONLY) {
+                $question['maxmark'] = $qattempt->get_max_mark();
+            }
+            if ($displayoptions->marks >= question_display_options::MARK_AND_MAX) {
+                $question['mark'] = $quba->get_question_mark($slot);
+            }
+
+            $questions[] = $question;
+        }
+        return $questions;
+    }
+
+    /**
+     * Gets the group object with the provided id from the database.
+     *
+     * @param $groupid
+     * @return mixed
+     * @throws dml_exception
+     * @throws moodle_exception
+     */
+    private static function get_group($groupid) {
+        global $DB;
+        if (!$group = $DB->get_record("offlinequiz_groups", ['id' => $groupid])) {
+            print_error("The offlinequiz group with $groupid is missing");
+        }
+        return $group;
+    }
+
+    /**
+     * Gets the offlinequiz object with the provided id from the database.
+     *
+     * @param $id
+     * @return mixed
+     * @throws dml_exception
+     * @throws moodle_exception
+     */
+    private static function get_offlinequiz_record($id) {
+        global $DB;
+        if (!$offlinequiz = $DB->get_record('offlinequiz', ['id' => $id])) {
+            print_error('invalidofflinequizid', 'offlinequiz');
+        }
+        return $offlinequiz;
+    }
+
+    /**
+     * Gets structure for an offlinequiz. Used for return value definitions.
+     *
+     * @return external_single_structure
+     */
+    private static function offlinequiz_structure() {
+        return new external_single_structure(
+            [
+                'id' => new external_value(PARAM_INT, 'offlinequiz id'),
+                'course' => new external_value(PARAM_INT, 'course id the offlinequiz belongs to'),
+                'name' => new external_value(PARAM_TEXT, 'offlinequiz name'),
+                'intro' => new external_value(PARAM_RAW, 'Quiz introduction text.', VALUE_OPTIONAL),
+                'introformat' => new external_format_value('intro', VALUE_OPTIONAL),
+                'introfiles' => new external_files('Files in the introduction text', VALUE_OPTIONAL),
+                'time' => new external_value(PARAM_INT, 'Time of the quiz', VALUE_OPTIONAL),
+                'resultsavailable' => new external_value(PARAM_INT, 'whether allowed to view results and results exist', VALUE_OPTIONAL)
+            ], 'example information'
+        );
+    }
+
+    /**
+     * Gets an array with relevant offlinequiz information.
+     *
+     * @param $offlinequiz
+     * @param $context
+     * @return object
+     * @throws coding_exception
+     */
+    private static function export_offlinequiz($offlinequiz, $context) {
+        global $USER;
+        $quizdetails = new stdClass();
+        $quizdetails->id = $offlinequiz->id;
+        $quizdetails->course = $offlinequiz->course;
+        $quizdetails->name = external_format_string($offlinequiz->name, $context->id);
+        if (has_capability('mod/offlinequiz:view', $context)) {
+            // Format intro.
+            $options = ['noclean' => true];
+            list($quizdetails->intro, $quizdetails->introformat) =
+                external_format_text($offlinequiz->intro, $offlinequiz->introformat, $context->id, 'mod_quiz', 'intro', null, $options);
+            $quizdetails->introfiles = external_util::get_area_files($context->id, 'mod_quiz', 'intro', false, false);
+            if ($offlinequiz->time) {
+                $quizdetails->time = $offlinequiz->time;
+            }
+            $quizdetails->resultsavailable = intval(offlinequiz_get_user_results($offlinequiz->id, $USER->id)
+                and offlinequiz_results_open($offlinequiz));
+        }
+        return $quizdetails;
+    }
+
+    /**
+     * Describes a single question structure. Used for return value definition.
+     *
+     * @return external_single_structure the question data. Some fields may not be returned depending on the offlinequiz display settings.
+     */
+    private static function question_structure() {
+        return new external_single_structure(
+            [
+                'slot' => new external_value(PARAM_INT, 'slot number'),
+                'type' => new external_value(PARAM_ALPHANUMEXT, 'question type, i.e: multichoice'),
+                'sequencecheck' => new external_value(PARAM_INT, 'the number of real steps in this attempt', VALUE_OPTIONAL),
+                'lastactiontime' => new external_value(PARAM_INT, 'the timestamp of the most recent step in this question attempt',
+                    VALUE_OPTIONAL),
+                'hasautosavedstep' => new external_value(PARAM_BOOL, 'whether this question attempt has autosaved data',
+                    VALUE_OPTIONAL),
+                'state' => new external_value(PARAM_ALPHA, 'the state where the question is in.
+                    It will not be returned if the user cannot see it due to the quiz display correctness settings.',
+                    VALUE_OPTIONAL),
+                'status' => new external_value(PARAM_RAW, 'current formatted state of the question', VALUE_OPTIONAL),
+                'mark' => new external_value(PARAM_RAW, 'the mark awarded.
+                    It will be returned only if the user is allowed to see it.', VALUE_OPTIONAL),
+                'maxmark' => new external_value(PARAM_FLOAT, 'the maximum mark possible for this question attempt.
+                    It will be returned only if the user is allowed to see it.', VALUE_OPTIONAL),
+                'settings' => new external_value(PARAM_RAW, 'Question settings (JSON encoded).', VALUE_OPTIONAL),
+            ], 'The question data. Some fields may not be returned depending on the quiz display settings.'
+        );
+    }
+
+}

--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -1,0 +1,151 @@
+<?php
+
+use mod_offlinequiz\local\tests\base;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->dirroot . '/webservice/tests/helpers.php');
+require_once($CFG->dirroot . '/mod/offlinequiz/externallib.php');
+
+/**
+ * External mod offlinequiz functions unit tests
+ */
+class mod_offlinequiz_external_testcase extends externallib_advanced_testcase {
+
+    /**
+     * Test if the user only gets offlinequiz for enrolled courses
+     */
+    public function test_get_offlinequizs_by_courses() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course1 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse1',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course1->id);
+
+        $course2 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse2',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course2->id);
+
+        $course3 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse3',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $offlinequiz1 = self::getDataGenerator()->create_module('offlinequiz', [
+            'course' => $course1->id,
+            'name' => 'Offlinequiz Module 1',
+            'intro' => 'Offlinequiz module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $offlinequiz2 = self::getDataGenerator()->create_module('offlinequiz', [
+            'course' => $course2->id,
+            'name' => 'Offlinequiz Module 2',
+            'intro' => 'Offlinequiz module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $offlinequiz3 = self::getDataGenerator()->create_module('offlinequiz', [
+            'course' => $course3->id,
+            'name' => 'Offlinequiz Module 3',
+            'intro' => 'Offlinequiz module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $this->setUser($user);
+
+        $result = mod_offlinequiz_external::get_offlinequizzes_by_courses([]);
+
+        // user is enrolled only in course1 and course2, so the third offlinequiz module in course3 should not be included
+        $this->assertEquals(2, count($result->offlinequizzes));
+    }
+
+
+    /**
+     * Test if the user gets a valid offlinequiz from the endpoint
+     */
+    public function test_get_offlinequiz() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $offlinequiz = self::getDataGenerator()->create_module('offlinequiz', [
+            'course' => $course->id,
+            'name' => 'Offlinequiz Module',
+            'intro' => 'Offlinequiz module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $this->setUser($user);
+
+        $result = mod_offlinequiz_external::get_offlinequiz($offlinequiz->id);
+
+        // offlinequiz name should be equal to 'Offlinequiz Module'
+        $this->assertEquals('Offlinequiz Module', $result->offlinequiz->name);
+
+        // Course id in offlinequiz should be equal to the id of the course
+        $this->assertEquals($course->id, $result->offlinequiz->course);
+    }
+
+
+    /**
+     * Test if the user gets an exception when the offlinequiz is hidden in the course
+     */
+    public function test_get_offlinequiz_hidden() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $offlinequiz = self::getDataGenerator()->create_module('offlinequiz', [
+            'course' => $course->id,
+            'name' => 'Hidden Offlinequiz Module',
+            'intro' => 'Offlinequiz module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+            'visible' => 0,
+        ]);
+
+        $this->setUser($user);
+
+        // Test should throw require_login_exception
+        $this->expectException(require_login_exception::class);
+
+        $result = mod_offlinequiz_external::get_offlinequiz($offlinequiz->id);
+
+    }
+
+}

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -1,0 +1,59 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+class mod_offlinequiz_generator extends testing_module_generator {
+
+    /**
+     * Generator method creating a mod_offlinequiz instance.
+     *
+     *
+     * @param array|stdClass $record (optional) Named array containing instance settings
+     * @param array $options (optional) general options for course module. Can be merged into $record
+     * @return stdClass record from module-defined table with additional field cmid (corresponding id in course_modules table)
+     */
+    public function create_instance($record = null, array $options = null) {
+        $record = (object)(array)$record;
+
+        $timecreated = time();
+
+        $defaultsettings = [
+            'name' => 'Offlinequiz',
+            'intro' => 'Introtext',
+            'introformat' => 1,
+            'pdfintro' => 'pdf intro text',
+            'timeopen' => 0,
+            'timeclose' => 0,
+            'time' => 0,
+            'grade' => 100.0,
+            'numgroups' => 1,
+            'decimalpoints' => 2,
+            'review' => 0,
+            'questionsperpage' => 0,
+            'docscreated' => 0,
+            'shufflequestions' => 0,
+            'shuffleanswers' => 0,
+            'printstudycodefield' => 1,
+            'papergray' => 670,
+            'fontsize' => 10,
+            'timecreated' => $timecreated,
+            'showquestioninfo' => 0,
+            'timemodified' => $timecreated,
+            'fileformat' => 0,
+            'showgrades' => 0,
+            'showtutorial' => 0,
+            'id_digits' => 8,
+            'disableimgnewlines' => 0,
+            'algorithmversion' => 0,
+            'experimentalevaluation' => 0,
+        ];
+
+        foreach ($defaultsettings as $name => $value) {
+            if (!isset($record->{$name})) {
+                $record->{$name} = $value;
+            }
+        }
+
+        return parent::create_instance($record, (array)$options);
+    }
+}


### PR DESCRIPTION
Offlinequiz results can only be viewed with a browser. This PR solves
this problem by providing moodle webservice endpoints.
Currently only student-relevant endpoints are available as this is our
goal. However, the webservices can be extended easily.

To provide webservice functions for the mod_offlinequiz plugin following
additions were made:

- Added db/services.php which includes the description of the 3 endpoints
- Added tests/externallib_test.php which includes unit tests for the endpoints
- Added tests/generator/lib.php which includes the testing_module_generator for unit tests
- Added externallib.php which includes the actual endpoints.

Following endpoints were added:

- mod_offlinequiz_get_offlinequizzes_by_courses
- mod_offlinequiz_get_offlinequiz
- mod_offlinequiz_get_attempt_review

_The collection of PRs posted by us, providing webservice functions, is supposed to serve the use-case of providing a student API for TUWEL (TU Wien Moodle Platform). It is with that purpose in mind, that we chose the plugins and the functionality to provide via web service. The following PRs are related to this effort:_
- [Checkmark](https://github.com/academic-moodle-cooperation/moodle-mod_checkmark/pull/65)
- [Grouptool](https://github.com/academic-moodle-cooperation/moodle-mod_grouptool/pull/23)
- [Offline-Quiz](https://github.com/academic-moodle-cooperation/moodle-mod_offlinequiz/pull/151)
- [Organizer](https://github.com/academic-moodle-cooperation/moodle-mod_organizer/pull/97)
- [Publication](https://github.com/academic-moodle-cooperation/moodle-mod_publication/pull/51)