### PR TITLE
Update lib.php for boost themes (either parent or child theme)

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1341,13 +1341,13 @@ function offlinequiz_extend_settings_navigation($settings, $offlinequiznode) {
         $beforekey = $keys[$i + 1];
     }
 
-    if (has_capability('mod/offlinequiz:manage', $PAGE->cm->context)) {
+if (has_capability('mod/offlinequiz:manage', $PAGE->context)) {
         $active = offlinequiz_get_active_tab();
         //Tab Offlinequiz content.
         if($active == 'tabofflinequizcontent') {
             $url = $PAGE->url;
         } else {
-            $url = new moodle_url('/mod/offlinequiz/navigate.php', ['id' => $PAGE->cm->id, 'tab' => 'tabofflinequizcontent']);
+            $url = isset($PAGE->cm->id) ? new moodle_url('/mod/offlinequiz/navigate.php', ['id' => $PAGE->cm->id, 'tab' => 'tabofflinequizcontent']) : $PAGE->url;
         }
         $node = navigation_node::create(get_string('tabofflinequizcontent', 'offlinequiz'),
                 $url,
@@ -1358,7 +1358,7 @@ function offlinequiz_extend_settings_navigation($settings, $offlinequiznode) {
         if($active == 'tabresults') {
             $url = $PAGE->url;
         } else {
-            $url = new moodle_url('/mod/offlinequiz/navigate.php', ['id' => $PAGE->cm->id, 'tab' => 'tabresults']);
+            $url = isset($PAGE->cm->id) ? new moodle_url('/mod/offlinequiz/navigate.php', ['id' => $PAGE->cm->id, 'tab' => 'tabresults']) : $PAGE->url;
         }
         $node = navigation_node::create(get_string('tabresults', 'offlinequiz'),
             $url,
@@ -1369,7 +1369,7 @@ function offlinequiz_extend_settings_navigation($settings, $offlinequiznode) {
         if($active == 'tabstatistics') {
             $url = $PAGE->url;
         } else {
-            $url = new moodle_url('/mod/offlinequiz/report.php', array('id' => $PAGE->cm->id, 'mode' => 'statistics'));
+            $url =  isset($PAGE->cm->id) ? new moodle_url('/mod/offlinequiz/report.php', array('id' => $PAGE->cm->id, 'mode' => 'statistics')) : $PAGE->url;
         }
         $node = navigation_node::create(get_string('tabstatistics', 'offlinequiz'),
             $url,
@@ -1380,7 +1380,7 @@ function offlinequiz_extend_settings_navigation($settings, $offlinequiznode) {
         if($active == 'tabattendances') {
             $url = $PAGE->url;
         } else {
-            $url = new moodle_url('/mod/offlinequiz/navigate.php', ['id' => $PAGE->cm->id, 'tab' => 'tabattendances']);
+            $url = isset($PAGE->cm->id) ? new moodle_url('/mod/offlinequiz/navigate.php', ['id' => $PAGE->cm->id, 'tab' => 'tabattendances']) : $PAGE->url;
         }
         $node = navigation_node::create(get_string('tabattendances', 'offlinequiz'),
                 $url,
@@ -1390,8 +1390,6 @@ function offlinequiz_extend_settings_navigation($settings, $offlinequiznode) {
             $node->make_active();
         }
         $offlinequiznode->add_node($node, $beforekey);
-
-
     }
 
     question_extend_settings_navigation($offlinequiznode, $PAGE->cm->context)->trim_if_empty();


### PR DESCRIPTION
The changes are in the elses in the offlinequiz_extend_settings_navigation function, starting line 1327: 

It's not a bug, strickly speaking, that renders the mod unusable but if you're on a boost theme (parent or child) and if you're on debug mode you get errors on certain pages as the course parameters. 

This is caused by the navigation difference between boost and classic themes. 

To prevent this, The $url variable in the elses first check that $PAGE->cm->id is set (ternary). If it is then everything is fine and dandy. If not, then we still affect the $PAGE->url 

I guess it'd been possible to juste add "&& !isset($PAGE->cm->id)" to the if declaration but it seemed less readable for someone not familiar with the code.