### PR TITLE
fix url encoding issue

### DIFF
--- a/correct.php
+++ b/correct.php
@@ -964,9 +964,10 @@ $fs = get_file_storage();
 $imagefile = $fs->get_file($context->id, 'mod_offlinequiz', 'imagefiles', 0, '/', $scannedpage->filename);
 
 // Print image of the form sheet.
-echo '<img id="scannedimage" name="formimage" src="' . $CFG->wwwroot .
-   "/pluginfile.php/$context->id/mod_offlinequiz/imagefiles/0/" .
-   $imagefile->get_filename() .'" border="1" width="' . OQ_IMAGE_WIDTH .
+$imageurl = moodle_url::make_pluginfile_url($context->id, 'mod_offlinequiz', 'imagefiles', 0, '/', $imagefile->get_filename());
+
+echo '<img id="scannedimage" name="formimage" src="' . $imageurl . '"
+   border="1" width="' . OQ_IMAGE_WIDTH .
    '" style="position:absolute; top:0px; left:0px; display: block;">';
 
 


### PR DESCRIPTION
One of our users reported a problem while displaying the student scanned file.

The scanned file was present in the database, but the URL called was incorrect. The filename contained an escaped % character.

This patch should correctly encode the called URL.