### PR TITLE
Use Tabs interface instead of Select Url box.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -147,14 +147,17 @@ function offlinequiz_print_tabs($offlinequiz, $currenttab, $cm) {
     }
     $tabs = offlinequiz_get_tabs_object($offlinequiz, $cm);
     $ct = $tabs[$currenttab];
-    $options = [];
+  
+    // Create tabs structures.
+    $toprow = [];
     foreach ($tabs as $tabname => $tabobject) {
         if ($tabobject['tab'] == $ct['tab']) {
-            $options[$tabobject['url']->out()] = get_string($tabname, 'offlinequiz');
+            $title = isset($tabobject['title'])?$tabobject['title'] : get_string($tabname, 'offlinequiz');
+            $tabobj = new tabobject($tabname, $tabobject['url'], $title);
+            $toprow[] = $tabobj;
         }
     }
-    $selectobject = new \url_select($options);
-    echo $OUTPUT->render($selectobject);
+    echo $OUTPUT->tabtree($toprow, $currenttab);
 }
 
 function offlinequiz_get_tabs_object($offlinequiz, $cm) {


### PR DESCRIPTION
Our teachers get ussually confused because the sections of the application are hidden in the select box.
We propose that the navigation element be the standard "tabtree" object.

<img width="288" alt="image" src="https://github.com/academic-moodle-cooperation/moodle-mod_offlinequiz/assets/1656180/791ce213-e5f0-47d9-8056-5857c5d18f6d">

It seems more natural and accesible than the current select box.

I hope this PR will be useful and could be integrated in the project.

Best regards.