### PR TITLE
Fix Issue #182 in MOODLE_401_STABLE branch

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -40,7 +40,6 @@ class provider implements
 
         $collection->link_subsystem('core_files', 'privacy:metadata:core_files');
         $collection->link_subsystem('core_question', 'privacy:metadata:core_question');
-        $collection->link_subsystem('mod_quiz', 'privacy:metadata:mod_quiz');
 
         $collection->add_database_table(
           'offlinequiz',

--- a/lang/en/offlinequiz.php
+++ b/lang/en/offlinequiz.php
@@ -475,7 +475,6 @@ $string['printstudycodefield_help'] = 'If checked, the study code field will be 
 $string['privacy:data_folder_name'] = 'Offlinequiz data';
 $string['privacy:metadata:core_files'] = 'The offlinequiz uses the file API to store the generated question sheets, answer sheets and correction sheets as well as the filled out answer sheets.';
 $string['privacy:metadata:core_question'] = 'The offlinequiz uses the question API for saving the questions for the quizes.';
-$string['privacy:metadata:mod_quiz'] = 'The offlinequiz uses the quiz API for saving results of the quizes.';
 $string['privacy:metadata:offlinequiz:course'] = 'The \'course\' column in the offlinequiz table saves in which course this offlinequiz is stored in.';
 $string['privacy:metadata:offlinequiz:name'] = 'The \'name\' column saves the name of the offlinequiz.';
 $string['privacy:metadata:offlinequiz:introformat'] = 'This field is not used.';


### PR DESCRIPTION
Issue #182 was fixed in commit https://github.com/academic-moodle-cooperation/moodle-mod_offlinequiz/commit/cb73df2fed58c576cd6f8778d0cb87b35d7ad144 in the master branch. 

This PR cherry picks the commit and removes the privacy provider metadata language string as it is no longer referenced.