### PR TITLE
Fix Issue #247 in MOODLE_401_STABLE branch

### DIFF
--- a/report/regrade/classes/privacy/provider.php
+++ b/report/regrade/classes/privacy/provider.php
@@ -14,18 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Strings for component 'offlinequiz_rimport', language 'en'
- *
- * @package       mod
- * @subpackage    offlinequiz
- * @author        Juergen Zimmer <zimmerj7@univie.ac.at>
- * @copyright     2015 Academic Moodle Cooperation {@link http://www.academic-moodle-cooperation.org}
- * @since         Moodle 2.1
- * @license       http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- *
- **/
+namespace offlinequiz_regrade\privacy;
 
-$string['pluginname'] = 'Offlinequiz Regrading';
-$string['privacy:metadata'] = 'This plugin does not store any user related data.';
-$string['reallyregrade'] = 'Really regrade';
+defined('MOODLE_INTERNAL') || die();
+
+class provider implements
+// This plugin does not store any personal user data.
+\core_privacy\local\metadata\null_provider {
+    /**
+     * This plugin does not store any data
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}


### PR DESCRIPTION
This fixes Issue #247. The report/regrade does not have a privacy provider that causes the test failure.

This report no longer exists in the master and MOODLE_403_STABLE branches.

Use the following command to run the unit test for verification:
```
vendor/bin/phpunit --filter test_all_providers_compliant privacy/tests/privacy/provider_test.php
```