### PR TITLE
fix url encoding issue

### DIFF
--- a/image.php
+++ b/image.php
@@ -143,8 +143,8 @@ if ($sheetloaded) {
     $imagefile = $fs->get_file($context->id, 'mod_offlinequiz', 'imagefiles', 0, '/', $scannedpage->filename);
 
     // E.g. http://131.130.103.117/mod_offlinequiz/pluginfile.php/65/mod_offlinequiz/imagefiles/0/zimmer.png_1.
-    echo '<img name="formimage" src="' . $CFG->wwwroot . "/pluginfile.php/$context->id/mod_offlinequiz/imagefiles/0/" .
-    $imagefile->get_filename() .'" border="1" width="' . OQ_IMAGE_WIDTH .
+    $imageurl = moodle_url::make_pluginfile_url($context->id, 'mod_offlinequiz', 'imagefiles', 0, '/', $imagefile->get_filename());
+    echo '<img name="formimage" src="' . $imageurl . '" border="1" width="' . OQ_IMAGE_WIDTH .
         '" style="position:absolute; top:0px; left:0px; display: block;">';
 
     $answerspots = $scanner->export_hotspots_answer(OQ_IMAGE_WIDTH);

--- a/participants_correct.php
+++ b/participants_correct.php
@@ -543,8 +543,8 @@ $fs = get_file_storage();
 $imagefile = $fs->get_file($context->id, 'mod_offlinequiz', 'imagefiles', 0, '/', $scannedpage->filename);
 
 // Print image of the form sheet.
-echo '<img name="formimage" src="' . $CFG->wwwroot . "/pluginfile.php/$context->id/mod_offlinequiz/imagefiles/0/" .
-$imagefile->get_filename() .'" border="1" width="' . OQ_IMAGE_WIDTH .
+$imageurl = moodle_url::make_pluginfile_url($context->id, 'mod_offlinequiz', 'imagefiles', 0, '/', $imagefile->get_filename());
+echo '<img name="formimage" src="' . $imageurl . '" border="1" width="' . OQ_IMAGE_WIDTH .
 '" style="position:absolute; top:0px; left:0px; display: block;">';
 
 if ($scannedpage->status == 'error') {

--- a/review.php
+++ b/review.php
@@ -191,9 +191,8 @@ if ($isteacher or ($options->sheetfeedback == question_display_options::VISIBLE)
                 $fs = get_file_storage();
                 $imagefile = $fs->get_file($context->id, 'mod_offlinequiz', 'imagefiles', 0, '/',
                         $scannedpage->warningfilename);
-                echo '<br/>&nbsp;<br/><img name="formimage" src="' . $CFG->wwwroot .
-                 "/pluginfile.php/$context->id/mod_offlinequiz/imagefiles/0/" . $imagefile->get_filename() .
-                 '" border="1" width="760" />';
+                $imageurl = moodle_url::make_pluginfile_url($context->id, 'mod_offlinequiz', 'imagefiles', 0, '/', $imagefile->get_filename());
+                echo '<br/>&nbsp;<br/><img name="formimage" src="' . $imageurl . '" border="1" width="760" />';
             }
         }
         if ($found) {


### PR DESCRIPTION
Our context : Moodle 4.1 / mod_offlinequiz v4.1.7

One of our users reports a problem when a student displays his attempt.

The scanned file is present in the database, but the called URL is incorrect.

Step to reproduce the issue: upload a scanned file that contains a percentage character in its filename (e.g. test%.png)

This patch should correctly encode the called URL. I also fixed 2 other locations where I spotted this issue.

(this issue is similar to #188)