### PR TITLE
regenerates question usages when a question version is modified

### DIFF
--- a/classes/external/submit_question_version.php
+++ b/classes/external/submit_question_version.php
@@ -128,6 +128,12 @@ class submit_question_version extends external_api {
                 $response['result'] = $DB->update_record('question_references', $reference);
             }
             \offlinequiz_update_question_instance($offlinequiz,$context->id, $oldquestionid, $slotdata->maxmark, $newquestionid);
+
+            if ($canbeedited) {
+                // Regenerates question usages.
+                \offlinequiz_delete_template_usages($offlinequiz);
+            }
+
             $response['result'] = true;
         }
         return $response;


### PR DESCRIPTION
Our context : Moodle 4.1 / mod_offlinequiz v4.1.7

One of our users reports a problem on how offline quiz handles a change of question version in some cases.

Step to reproduce the issue :
1. in question bank, create a new multiple choice question with 4 choices
2. edit question and add 2 new choices
3. create a new offline quiz activity with default settings
4. add the question created previously to the offline quiz
5. go to forms page. The preview shows the question with 6 items. 
6. go back to questions page and select the first version of the question (with 4 choices)
7. return to forms page. The preview still shows the question with 6 items (instead of 4 expected items), but also with 2 empty choices.

The expected result should be a preview with only 4 items.

Screenshot:
![image](https://github.com/academic-moodle-cooperation/moodle-mod_offlinequiz/assets/5418227/9c7320a5-e246-4047-9179-35fcfbf20792)

One workaround is to reload the question list to remove the 2 empty choices.

So, I suggest to always call `offlinequiz_delete_template_usages()` function when a teacher changes the version of a question.

What do you think of it? Is it the right way to fix this issue?