### PR TITLE
fix #221 Answers can still break the PDFs.

### DIFF
--- a/pdflib.php
+++ b/pdflib.php
@@ -455,7 +455,7 @@ function offlinequiz_get_answers_html($offlinequiz, $templateusage,
         if (!empty($texfilter)) {
             $answertext = $texfilter->filter($answertext);
         }
-        if($question->options->answers[$answer]->answerformat == FORMAT_PLAIN) {
+        if($question->options->answers[$answer]->answerformat != FORMAT_HTML) {
             $answertext = s($answertext);
         }
         // Remove all HTML comments (typically from MS Office).


### PR DESCRIPTION
fix #221
Answers with  FORMAT_MOODLE, FORMAT_MARKDOWN still breaks the PDFs if contains < > characters.

This small change works in my test-cases.