### PR TITLE
Deprecated get_plugin_list warning

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -210,38 +210,40 @@ function offlinequiz_get_tabs_object($offlinequiz, $cm): navigation_node {
         text: get_string('tabpreview', 'offlinequiz'), 
         action: new moodle_url('/mod/offlinequiz/navigate.php', ['tab' => 'tabforms', 'id' => $cm->id]),
         key: 'tabpreview');
-    // Populate participants tab.
+    // Populate participants tab if it exists. Participants menu exists if "record attendance" is enabled.
     $participantsnode = $secondarynav->get('mod_offlinequiz_participants');
-    // Add "Edit lists" tab.
-    $participantsnode->add(
-        text: get_string('tabparticipantlists', 'offlinequiz'),
-        action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'editlists']),
-        key: 'tabparticipantlists');
-    // Add "Edit participants" tab.
-    $participantsnode->add(
-        text: get_string('tabeditparticipants', 'offlinequiz'),
-        action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'editparticipants']),
-        key: 'tabeditparticipants');
-    // Add "Create PDFs" tab.
-    $participantsnode->add(
-        text: get_string('tabdownloadparticipantsforms', 'offlinequiz'),
-        action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'createpdfs']),
-        key: 'tabdownloadparticipantsforms');
-    // Add "Upload" tab.
-    $participantsnode->add(
-        text: get_string('tabparticipantsupload', 'offlinequiz'),
-        action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'upload']),
-        key: 'tabparticipantsupload');
-    // Add "Correct" tab.
-    $participantsnode->add(
-        text: get_string('tabparticipantscorrect', 'offlinequiz'),
-        action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'correct']),
-        key: 'tabparticipantscorrect');
-    // Add "Attendances" tab.
-    $participantsnode->add(
-        text: get_string('attendances', 'offlinequiz'),
-        action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'attendances']),
-        key: 'tabattendancesoverview');
+    if ($participantsnode) {
+        // Add "Edit lists" tab.
+        $participantsnode->add(
+            text: get_string('tabparticipantlists', 'offlinequiz'),
+            action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'editlists']),
+            key: 'tabparticipantlists');
+        // Add "Edit participants" tab.
+        $participantsnode->add(
+            text: get_string('tabeditparticipants', 'offlinequiz'),
+            action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'editparticipants']),
+            key: 'tabeditparticipants');
+        // Add "Create PDFs" tab.
+        $participantsnode->add(
+            text: get_string('tabdownloadparticipantsforms', 'offlinequiz'),
+            action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'createpdfs']),
+            key: 'tabdownloadparticipantsforms');
+        // Add "Upload" tab.
+        $participantsnode->add(
+            text: get_string('tabparticipantsupload', 'offlinequiz'),
+            action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'upload']),
+            key: 'tabparticipantsupload');
+        // Add "Correct" tab.
+        $participantsnode->add(
+            text: get_string('tabparticipantscorrect', 'offlinequiz'),
+            action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'correct']),
+            key: 'tabparticipantscorrect');
+        // Add "Attendances" tab.
+        $participantsnode->add(
+            text: get_string('attendances', 'offlinequiz'),
+            action: new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'attendances']),
+            key: 'tabattendancesoverview');
+    }
 
     // Add navigation from subplugins.
     $pluginmanager = core_plugin_manager::instance();

--- a/report/identified/README.md
+++ b/report/identified/README.md
@@ -1,0 +1,32 @@
+# Identified forms for Offlinequiz #
+
+This subplugin allow to generate a set of "Answer forms" with the names and identifiers of the students pre-marked.
+The selection of students can be controlled by:
+
+- Editing "attendance lists" in Offlinequiz itself.
+- Checking "Students with access" to the activity according to restrictions and conditional access.
+
+The pre-marked forms can be used to reduce human errors and to easy the physical control of the identities of the students in the classroom.
+
+# Release
+
+- v0.1.0 Support for 4.5+ versions.
+- v0.0.1 Initial release.
+
+# Copyright
+
+This plugin was implemented by Juan Pablo de Castro <juan.pablo.de.castro@gmail.com>
+
+## License ##
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/report/identified/classes/answer_pdf_identified.php
+++ b/report/identified/classes/answer_pdf_identified.php
@@ -1,0 +1,100 @@
+<?php
+// This file is part of mod_offlinequiz for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The mod_offlinequiz identifiedformsselector
+ *
+ * @package   offlinequiz_identified
+ * @author    Juan Pablo de Castro <juanpablo.decastro@uva.es>
+ * @copyright 2023
+ * @since     Moodle 4.1
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace offlinequiz_identified;
+
+defined('MOODLE_INTERNAL') || die();
+/**
+ * PDF forms generator for offlinequizzes with participant identification.
+ * Call set_participant($participant) to set the participant data and then add_answer_page(...) to add the answer page.
+ */
+class answer_pdf_identified extends \offlinequiz_answer_pdf {
+    public $participant = null;
+    public $listno = null;
+
+    public function Header(){
+        global $CFG;
+        // Participant data.
+        $participant = $this->participant;
+        parent::Header();
+        $offlinequizconfig = get_config('offlinequiz');
+        $pdf = $this;
+        // Marks identity.
+        if ($participant != null) {
+            $idnumber = $participant->{$offlinequizconfig->ID_field};
+            // Pad with zeros.
+            $idnumber = str_pad($idnumber, $offlinequizconfig->ID_digits, '0', STR_PAD_LEFT);
+            $pdf->SetFont('FreeSans', '', 8);
+            $pdf->setXY(34.4,  29);
+            $pdf->Cell(90, 7, ' '.offlinequiz_str_html_pdf($participant->firstname), 0, 0, 'L');
+            $pdf->setXY(34.4,  36);
+            $pdf->Cell(90, 7, ' '.offlinequiz_str_html_pdf($participant->lastname), 0, 1, 'L');
+            // Print Check test.
+        
+            $pdf->SetFont('FreeSans', '', 12);
+            $pdf->SetXY(137, 34);
+
+            for ($i = 0; $i < $offlinequizconfig->ID_digits; $i++) {      // Userid digits.
+                $pdf->SetXY(137 + $i*6.5, 34);
+                $this->Cell(7, 7, $idnumber[$i], 0, 0, 'C');
+            }
+
+            $pdf->SetDrawColor(0);
+
+            // Print boxes for the user ID number.
+            for ($i = 0; $i < $offlinequizconfig->ID_digits; $i++) {
+                $x = 139 + 6.5 * $i;
+                for ($j = 0; $j <= 9; $j++) {
+                    $y = 44 + $j * 6;
+                    $pdf->SetXY($x, $y);
+                    $pdf->Cell(2.7,  1, '', 0, 0, 'C');
+                    if ($idnumber[$i] == $j) {
+                        $pdf->Image("$CFG->dirroot/mod/offlinequiz/pix/kreuz.gif", $x ,  $y + 0.15,  3.15,  0);
+                    }
+                }
+            }
+        }
+    }
+    public function set_participant($participant) {
+        $this->participant = $participant;
+    }
+    /**
+     * Add a new answer page to the PDF with identification of the participant.
+     * @param mixed $participant
+     * @param int-mask-of $maxanswers
+     * @param mixed $templateusage
+     * @param mixed $offlinequiz
+     * @param mixed $group
+     * @param int $courseid
+     * @param mixed $context
+     * @param string $groupletter
+     * @return void
+     */
+    public function add_participant_answer_page( $participant, $maxanswers, $templateusage, $offlinequiz, $group, $courseid, $context, $groupletter) {
+        $this->set_participant($participant);
+        $this->add_answer_page( $maxanswers, $templateusage, $offlinequiz, $group, $courseid, $context, $groupletter);
+    }
+
+}

--- a/report/identified/classes/identifiedformselector.php
+++ b/report/identified/classes/identifiedformselector.php
@@ -1,0 +1,97 @@
+<?php
+// This file is part of mod_offlinequiz for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The mod_offlinequiz identifiedformsselector
+ *
+ * @package   offlinequiz_identified
+ * @author    Juan Pablo de Castro <juanpablo.decastro@uva.es>
+ * @copyright 2023
+ * @since     Moodle 4.1
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace offlinequiz_identified;
+
+use html_writer;
+
+defined('MOODLE_INTERNAL') || die();
+
+class identifiedformselector extends \moodleform {
+    // Constructor.
+    public function __construct($action, $customdata, $method = 'post', $target = '', $attributes = null, $editable = true) {
+        parent::__construct($action, $customdata, $method, $target, $attributes, $editable);
+    }  
+    public function definition() {
+        global $CFG, $DB;
+        $offlinequiz = $this->_customdata['offlinequiz'];
+        $cmid = $this->_customdata['id'];
+        $sql = "SELECT id, name, listnumber, filename
+        FROM {offlinequiz_p_lists}
+        WHERE offlinequizid = :offlinequizid
+        ORDER BY name ASC";
+        $lists = $DB->get_records_sql($sql, array('offlinequizid' => $offlinequiz->id));
+        $groups = $DB->get_records(
+            'offlinequiz_groups',
+            array('offlinequizid' => $offlinequiz->id),
+            'groupnumber',
+            'groupnumber',
+            0,
+            $offlinequiz->numgroups
+        );
+        // Map groups to letters.
+        $groupsoptions = [];
+        foreach ($groups as $group) {
+            $letterstr = "ABCDEFGH"; 
+            $letter = $letterstr[$group->groupnumber-1];
+            $groupsoptions[] = $letter;
+            };
+        
+        // Map lists to list->name.
+        $lists = array_map(function($list) use ($offlinequiz) {
+                $alluserids = offlinequizidentified_get_participants($offlinequiz, $list, false);
+                $accessuserids = offlinequizidentified_get_participants($offlinequiz, $list, true);
+                $numusers = count($alluserids);
+                $numaccessusers = count($accessuserids);
+                if ($numaccessusers != $numusers) {
+                    $listname = $list->name . ' (' . $numaccessusers . '/'. $numusers . ')';
+                } else {
+                    $listname = $list->name . '(' . $numusers . ')';
+                }
+                return $listname;
+            }, $lists);
+        $mform = $this->_form;
+        $mform->addElement('hidden', 'id', $cmid);
+        $mform->setType('id', PARAM_INT);
+        $mform->addElement('hidden', 'mode', 'identified');
+        $mform->setType('mode', PARAM_TEXT);
+        $mform->addElement('select', 'groupnumber', get_string('group', 'offlinequiz'), $groupsoptions);
+        $mform->setType('groupnumber', PARAM_INT);
+        $mform->setDefault('groupnumber', 0);
+        $mform->addRule('groupnumber', null, 'required', null, 'client');
+        // Check box for nor marking group.
+        $mform->addElement('checkbox', 'nogroupmark', get_string('nogroupmark', 'offlinequiz_identified'));
+        $mform->setDefault('nogroupmark', 0);
+        
+        $mform->addElement('select', 'list', get_string('participants', 'offlinequiz'), $lists);
+        $mform->setType('list', PARAM_INT);
+        $mform->setDefault('list', 0);
+        // Check box for only if access.
+        $mform->addElement('checkbox', 'onlyifaccess', get_string('onlyifaccess', 'offlinequiz_identified'));
+        // Set list required.
+        $mform->addRule('list', null, 'required', null, 'client');
+        $mform->addElement('submit', 'submitbutton', get_string('submit'));
+    }
+}

--- a/report/identified/classes/report.php
+++ b/report/identified/classes/report.php
@@ -1,0 +1,119 @@
+<?php
+// This file is part of mod_offlinequiz for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Offlinequiz identified forms generator version info
+ *
+ * @package       mod_offlinequiz
+ * @subpackage    report_identified
+ * @author        Juan Pablo de Castro <juanpablo.decastro@uva.es>
+ * @copyright     2023
+ * @since         Moodle 4.1
+ * @license       http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ **/
+namespace offlinequiz_identified;
+use mod_offlinequiz\default_report;
+use \navigation_node;
+use \moodle_url;
+defined('MOODLE_INTERNAL') || die();
+require_once("report/identified/locallib.php");
+/**
+ * Offlinequiz identified forms generator.
+ */
+class report extends default_report
+{
+
+    public function display($offlinequiz, $cm, $course)
+    {
+        global $CFG, $OUTPUT, $PAGE, $DB;
+        $context = \context_module::instance($cm->id);
+        $toform = ['id' => $cm->id, 'offlinequiz' => $offlinequiz, 'listid' => null, 'groupid' => null];
+        $mform = new identifiedformselector(null, $toform, 'get');
+        // Disable if forms are not generated.
+        if ($offlinequiz->docscreated == 1) {
+
+            $resultmsg = "";
+            // Form processing and displaying is done here.
+            if ($fromform = $mform->get_data()) {
+                $listid = isset($fromform->list)? $fromform->list : -1;
+                $groupid = $fromform->groupnumber+1;
+                $nogroupmark = isset($fromform->nogroupmark);
+                $onlyifaccess = isset($fromform->onlyifaccess) ? $fromform->onlyifaccess : false;
+                $list = $DB->get_record('offlinequiz_p_lists', array('offlinequizid' => $offlinequiz->id, 'id' => $listid));
+                if ($list) {
+                    raise_memory_limit(MEMORY_EXTRA);
+                    if (offlinequiz_create_pdf_participants_answers($offlinequiz, $course->id, $groupid, $list, $context, $nogroupmark, $onlyifaccess)) {
+                        // PDF created and downloaded.
+                        die();
+                    } else {
+                        $resultmsg = get_string('noparticipantsinlist', 'offlinequiz_identified');
+                    };
+                } else {
+                    $resultmsg = get_string('noparticipantsinlist', 'offlinequiz_identified');
+                };
+            }
+        }
+
+        // Set anydefault data (if any).
+        $mform->set_data($toform);
+       
+        // Display Tabs.
+        $this->print_header_and_tabs($cm, $course, $offlinequiz, 'identified');
+        // Display the header.
+        echo $OUTPUT->heading(get_string('identified', 'offlinequiz_identified'), 2);
+
+        if ($offlinequiz->docscreated == 0) {
+            // url createquiz.
+            $url = new moodle_url('/mod/offlinequiz/createquiz.php', ['q' => $offlinequiz->id, 'tabs' => 'tabpreview']);
+            echo $OUTPUT->notification(get_string('notgenerated', 'offlinequiz_identified', $url->out()), 'notifyproblem');
+            return true;
+        } else {
+            // Display the result message.
+            if ($resultmsg) {
+                echo $OUTPUT->notification($resultmsg, 'notifyproblem');
+            }
+            // Display the description.
+            // Url: participants.php?q=1&mode=editlists.
+            $url = new moodle_url('/mod/offlinequiz/participants.php', ['q' => $offlinequiz->id, 'mode' => 'editlists', 'tabs'=>'tabattendances']);
+            echo $OUTPUT->box(get_string('identifiedreport', 'offlinequiz_identified', $url->out()), 'generalbox', 'intro');
+            // Display the form.
+            $mform->display();
+        }
+        return true;
+    }
+   
+    public function add_to_navigation(navigation_node $navigation, $cm, $offlinequiz): navigation_node
+    {
+        // Add navigation nodes to mod_tabofflinequizcontent and mod_tabattendances.
+        $url = new moodle_url('/mod/offlinequiz/report.php', ['mode' => 'identified', 'id' => $cm->id]);
+        $navnode= navigation_node::create(text: get_string('identified', 'offlinequiz_identified'),
+                                         action: $url,
+                                         key: $this->get_navigation_key());
+
+        // Get tabofflinequizcontent.
+        $parentnode = $navigation->get('mod_offlinequiz_edit');
+        $parentnode->add_node($navnode);
+               
+        return $navigation;
+    }
+    public function get_report_title(): string {
+        return get_string('pluginname', 'offlinequiz_identified');
+    }
+    public function get_navigation_key(): string {
+        return 'tab_identifiedforms';
+    }
+}

--- a/report/identified/lang/en/error.php
+++ b/report/identified/lang/en/error.php
@@ -1,0 +1,18 @@
+<?php
+// This file is part of mod_offlinequiz for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+$string['missinggroup'] = 'Missing data for group {$a}';
+$string['noroles'] ='No roles with capability \'mod/offlinequiz:attempt\' defined in system context';

--- a/report/identified/lang/en/offlinequiz_identified.php
+++ b/report/identified/lang/en/offlinequiz_identified.php
@@ -1,0 +1,23 @@
+<?php
+// This file is part of mod_offlinequiz for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+$string['pluginname'] = 'Identified forms';
+$string['identified'] = 'Identified forms';
+$string['identifiedreport'] = 'Select group and list to generate the premarked forms. It may take a while depending on the number of students. Create your lists in the <a href="{$a}">Attendance lists section.</a>';
+$string['noparticipantsinlist'] = 'There are no participants in the selected list';
+$string['notgenerated'] = 'The forms have not been generated yet. Please, go to the <a href="{$a}">Preparation section</a> and create your exams.';
+$string['nogroupmark'] = 'Don\'t mark group checkbox.';
+$string['onlyifaccess'] = 'Only for students with access to this offline quiz.';

--- a/report/identified/lang/es/offlinequiz_identified.php
+++ b/report/identified/lang/es/offlinequiz_identified.php
@@ -1,0 +1,23 @@
+<?php
+// This file is part of mod_offlinequiz for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+$string['pluginname'] = 'Formularios identificados';
+$string['identified'] = 'Formularios con estudiantes premarcados';
+$string['identifiedreport'] = 'Seleccione modelo de examen y lista para generar los formularios premarcados. Puede tardar un poco dependiendo del número de alumnos. Cree sus listas en la sección <a href="{$a}">Listas de asistencia.</a>';
+$string['noparticipantsinlist'] = 'No hay participantes en la lista seleccionada';
+$string['notgenerated'] = 'Los formularios no se han generado todavía. Por favor, vaya a la sección <a href="{$a}">Preparación y cree sus exámenes</a>.';
+$string['nogroupmark'] = 'No marcar la casilla del modelo de examen.';
+$string['onlyifaccess'] = 'Sólo para los estudiantes con acceso a este cuestionario offline.';

--- a/report/identified/locallib.php
+++ b/report/identified/locallib.php
@@ -1,0 +1,209 @@
+<?php
+// This file is part of mod_offlinequiz for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Creates the PDF forms for offlinequizzes
+ *
+ * @package       mod
+ * @subpackage    offlinequiz
+ * @author        Juan Pablo de Castro <juanpablo.decastro@uva.es>
+ * @copyright     2023 Universidad de Valladolid {@link http://www.uva.es}
+ * @since         Moodle 4.1+
+ * @license       http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/moodlelib.php');
+require_once($CFG->libdir . '/pdflib.php');
+require_once($CFG->libdir . '/questionlib.php');
+require_once($CFG->dirroot . '/question/type/questionbase.php');
+require_once($CFG->libdir . '/formslib.php');
+require_once($CFG->dirroot . '/mod/offlinequiz/pdflib.php');
+/**
+ * Generator of answer forms with participant identification.
+ */
+class offlinequiz_answer_pdf_identified extends offlinequiz_answer_pdf {
+    public $participant = null;
+    public $listno = null;
+
+    public function Header(){
+        global $CFG, $DB;
+        // participant data.
+        parent::Header();
+        $offlinequizconfig = get_config('offlinequiz');
+        $pdf = $this;
+        $participant = $this->participant;
+        // Marks identity.
+        if ($participant != null) {
+            $idnumber = $participant->{$offlinequizconfig->ID_field};
+            // Pad with zeros.
+            $idnumber = str_pad($idnumber, $offlinequizconfig->ID_digits, '0', STR_PAD_LEFT);
+            $pdf->SetFont('FreeSans', '', 8);
+            $pdf->setXY(34.4,  29);
+            $pdf->Cell(90, 7, ' '.offlinequiz_str_html_pdf($participant->firstname), 0, 0, 'L');
+            $pdf->setXY(34.4,  36);
+            $pdf->Cell(90, 7, ' '.offlinequiz_str_html_pdf($participant->lastname), 0, 1, 'L');
+            // Print Check test.
+        
+            $pdf->SetFont('FreeSans', '', 12);
+            $pdf->SetXY(137, 34);
+
+            for ($i = 0; $i < $offlinequizconfig->ID_digits; $i++) {      // Userid digits.
+                $pdf->SetXY(137 + $i*6.5, 34);
+                $this->Cell(7, 7, $idnumber[$i], 0, 0, 'C');
+            }
+
+            $pdf->SetDrawColor(0);
+
+            // Print boxes for the user ID number.
+            for ($i = 0; $i < $offlinequizconfig->ID_digits; $i++) {
+                $x = 139 + 6.5 * $i;
+                for ($j = 0; $j <= 9; $j++) {
+                    $y = 44 + $j * 6;
+                    $pdf->SetXY($x, $y);
+                    $pdf->Cell(2.7,  1, '', 0, 0, 'C');
+                    if ($idnumber[$i] == $j) {
+                        $pdf->Image("$CFG->dirroot/mod/offlinequiz/pix/kreuz.gif", $x ,  $y + 0.15,  3.15,  0);
+                    }
+                }
+            }
+        }
+    }
+}
+
+function offlinequizidentified_get_participants($offlinequiz, $list, $onlyifaccess = false) {
+    global $CFG, $DB;
+    $coursemodule = get_coursemodule_from_instance('offlinequiz', $offlinequiz->id);
+    $courseid = $coursemodule->course;
+    $coursecontext = \context_course::instance($courseid); // Course context.
+    $systemcontext = \context_system::instance();
+
+    $offlinequizconfig = get_config('offlinequiz');
+    $listname = $list->name;
+
+    // First get roleids for students.
+    if (!$roles = get_roles_with_capability('mod/offlinequiz:attempt', CAP_ALLOW, $systemcontext)) {
+        throw new \moodle_exception('noroles', 'offlinequiz_identified');
+    }
+
+    $roleids = array();
+    foreach ($roles as $role) {
+        $roleids[] = $role->id;
+    }
+
+    list($csql, $cparams) = $DB->get_in_or_equal($coursecontext->get_parent_context_ids(true), SQL_PARAMS_NAMED, 'ctx');
+    list($rsql, $rparams) = $DB->get_in_or_equal($roleids, SQL_PARAMS_NAMED, 'role');
+    $params = array_merge($cparams, $rparams);
+    // Get all users that are in the list. TODO: Use explicit JOINS.
+    $sql = "SELECT DISTINCT u.id, u." . $offlinequizconfig->ID_field . ", u.firstname, u.lastname
+        FROM {user} u,
+            {offlinequiz_participants} p,
+            {role_assignments} ra,
+            {offlinequiz_p_lists} pl
+    WHERE ra.userid = u.id
+        AND p.listid = :listid
+        AND p.listid = pl.id
+        AND pl.offlinequizid = :offlinequizid
+        AND p.userid = u.id
+        AND ra.roleid $rsql AND ra.contextid $csql
+    ORDER BY u.lastname, u.firstname";
+
+    $params['offlinequizid'] = $offlinequiz->id;
+    $params['listid'] = $list->id;               
+    // $sql = "SELECT p.userid
+    //         FROM {offlinequiz_participants} p, {offlinequiz_p_lists} pl
+    //         WHERE p.listid = pl.id
+    //         AND pl.offlinequizid = :offlinequizid
+    //         AND p.listid = :listid";
+    // $params = array('offlinequizid' => $offlinequiz->id, 'listid' => $list->id);
+
+    $users = $DB->get_records_sql($sql, $params);
+    if ($onlyifaccess) {
+        $filtereduserids = [];
+        // Check what users can access this module using condition api.
+        // Get cm from instance id.
+        $coursemodule = get_coursemodule_from_instance('offlinequiz', $offlinequiz->id);
+        $cmid = $coursemodule->id;
+        foreach ($users as $user) {
+            // Get cm_info.
+            $modinfo = get_fast_modinfo($coursemodule->course, $user->id);
+            $cm = $modinfo->get_cm($cmid);
+
+            if ( $cm->available) {
+                $filtereduserids[$user->id] = $user;
+            }                
+        }
+        return $filtereduserids;   
+    } else {
+        return $users;
+    }
+}
+/**
+ * Creates a PDF document for a list of participants
+ *
+ * @param unknown_type $offlinequiz
+ * @param int $courseid
+ * @param unknown_type $list
+ * @param unknown_type $context
+ * @return boolean
+ */
+function offlinequiz_create_pdf_participants_answers($offlinequiz, $courseid, $groupnumber, $list, $context, $nogroupmark=false, $onlyifaccess = false) {
+    global $CFG, $DB;
+    // Get the participants filtering by access if requested.
+    $participants = offlinequizidentified_get_participants($offlinequiz, $list, $onlyifaccess);
+    if (empty($participants)) {
+        return false;
+    }
+
+    $pdf = new offlinequiz_identified\answer_pdf_identified('P', 'mm', 'A4');
+    
+    $pdf->listno = $list->listnumber;
+    $title = offlinequiz_str_html_pdf($offlinequiz->name);
+    // Add the list name to the title.
+    $title .= ', '.offlinequiz_str_html_pdf($list->name);
+    $pdf->set_title($title);
+    $pdf->SetMargins(15, 25, 15);
+    $pdf->SetAutoPageBreak(true, 20);
+
+    if ($nogroupmark==true){
+        $groupletter = '';
+    } else {
+        $letterstr = ' ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        $groupletter = $letterstr[$groupnumber];
+    }
+    // Answer pages.
+    $group = $DB->get_record('offlinequiz_groups', array('offlinequizid' => $offlinequiz->id, 'groupnumber' => $groupnumber));
+  
+    $pdf->SetFont('FreeSans', '', 10);
+    $maxanswers= offlinequiz_get_maxanswers($offlinequiz, array($group));
+    if (!$templateusage = offlinequiz_get_group_template_usage($offlinequiz, $group, $context)) {
+        throw new \moodle_exception(
+            "missinggroup" ,
+            "offlinequiz_identified",
+            "createquiz.php?q=$offlinequiz->id&amp;mode=preview&amp;sesskey=".sesskey(),
+            $groupletter
+        );
+    }
+ 
+    foreach ($participants as $participant) {
+        $pdf->add_participant_answer_page( $participant, $maxanswers, $templateusage, $offlinequiz, $group, $courseid, $context, $groupletter);
+    }
+
+    $pdf->Output("{$offlinequiz->name}_{$list->name}.pdf", 'D');
+    return true;
+}
+

--- a/report/identified/version.php
+++ b/report/identified/version.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of mod_offlinequiz for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Offlinequiz identified forms generator version info
+ *
+ * @package       mod
+ * @subpackage    offlinequiz
+ * @author        Juan Pablo de Castro <juanpablo.decastro@uva.es>
+ * @copyright     2023
+ * @since         Moodle 4.1
+ * @license       http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ **/
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->version  = 2025042400;
+$plugin->release = 'v0.1.0';
+$plugin->requires = 2011060313;
+$plugin->component = 'offlinequiz_identified';
+$plugin->maturity = MATURITY_STABLE;
+$plugin->dependencies = array(
+    'mod_offlinequiz' => 2025020100,
+);

--- a/report/reportlib.php
+++ b/report/reportlib.php
@@ -50,7 +50,7 @@ function offlinequiz_report_list($context) {
     }
 
     $reports = $DB->get_records('offlinequiz_reports', null, 'displayorder DESC', 'name, capability');
-    $reportdirs = get_plugin_list('offlinequiz');
+    $reportdirs = core_component::get_plugin_list('offlinequiz');
 
     // Order the reports tab in descending order of displayorder.
     $reportcaps = array();


### PR DESCRIPTION
Just changed to core_component::get_plugin_list()

Deprecation: get_plugin_list has been deprecated since 4.5. Use core_component::get_plugin_list instead. See MDL-82287 for more information.
line 255 of /lib/classes/deprecation.php: call to debugging()
line 136 of /lib/classes/deprecation.php: call to core\deprecation::emit_deprecation_notice()
line 115 of /lib/deprecatedlib.php: call to core\deprecation::emit_deprecation_if_present()
line 53 of /mod/offlinequiz/report/reportlib.php: call to get_plugin_list()
line 83 of /mod/offlinequiz/report.php: call to offlinequiz_report_list()