### PR TITLE
< character breaks DOCX, others are rendered as escaped html_entities

### DIFF
--- a/docxlib.php
+++ b/docxlib.php
@@ -63,7 +63,7 @@ function offlinequiz_print_blocks_docx($section, $blocks, $numbering = null, $de
         }
 
         $listitemrun = $section->addListItemRun($depth, 'questionnumbering');
-        $listitemrun->addText(htmlspecialchars(html_entity_decode($itemstring)), $style);
+        $listitemrun->addText(html_entity_decode($itemstring), $style);
         // We also skip the first sequential newline because we got a newline with addListItem.
         if (!empty($blocks) && $blocks[0]['type'] == 'newline') {
             array_shift($blocks);
@@ -86,7 +86,7 @@ function offlinequiz_print_blocks_docx($section, $blocks, $numbering = null, $de
                     continue;
                 }
                 if (array_key_exists('style', $block) && !empty($block['style'])) {
-                    $textrun->addText(htmlspecialchars(html_entity_decode($block['value'])), $block['style']);
+                    $textrun->addText(html_entity_decode($block['value']), $block['style']);
                 } else {
                     $textrun->addText(htmlspecialchars(html_entity_decode($block['value'])), 'nStyle');
                 }
@@ -451,6 +451,7 @@ function offlinequiz_create_docx_question(question_usage_by_activity $templateus
 
     $docx = new \PhpOffice\PhpWord\PhpWord();
     $trans = new offlinequiz_html_translator();
+    \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(true);   // Escape < and other characters.
 
     // Define cell style arrays.
     $cellstyle = array('valign' => 'center');


### PR DESCRIPTION
I found that if any text has "<" character, the resulting DOCX is corrupt because it breaks internal XML.

Moreover, characters as ">" is rendered as html entities, i.e. >

The solution seems to be tellign phpword to escape the characters internally and do not preprocess the texts in docxlib.php (see #306 ).

Steps to reproduce:

name the activity "Test <"
add a question with "<" and ">" chars.
generate DOCX forms.
Forms are corrupt if there is any "<" char.
If there is no "<" char, forms shows $gt; if there is a ">" char. Other html entities are escaped.

This issue is closelly related to https://github.com/academic-moodle-cooperation/moodle-mod_offlinequiz/issues/221