### PR TITLE
Use notifications API and fix some bugs.

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -1,0 +1,36 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Defines message providers (types of messages being sent)
+ *
+ * @package   mod_offlinequiz
+ * @copyright 2025 onwards  Juan Pablo de Castro  <juan.pablo.de.castro@gmail.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$messageproviders = array (
+    // Ordinary single offlinequiz posts.
+    'jobs' => array(
+        'defaults' => [
+            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+            'airnotifier' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+            'appcrue' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+        ],
+    ),
+);

--- a/report/rimport/classes/task/adhoc/extract_files.php
+++ b/report/rimport/classes/task/adhoc/extract_files.php
@@ -31,7 +31,7 @@ class extract_files extends \core\task\adhoc_task {
         $queue->status = 'processing';
         $DB->update_record('offlinequiz_queue',$queue);
         try {
-            if($queuedatas = $DB->get_record('offlinequiz_queue_data',['queueid' =>$queue->id])) {
+            if($queuedatas = $DB->get_records('offlinequiz_queue_data',['queueid' =>$queue->id])) {
                 //This is a rerun. Just queue all the files again and we're done
                 $DB->set_field('offlinequiz_queue_data', 'status', 'new', ['queueid' =>$queue->id]);
                 $DB->set_field('offlinequiz_queue_data', 'error', '', ['queueid' =>$queue->id]);


### PR DESCRIPTION
This PR use message API instead of direct email_to_user. This integrates the notifications into Moodle's messaging system (enable/disable, customize, message output plugins, etc.) increasing flexibility and supporting official APIs.

This implements:
- Messageprovider declaration.
- Send messages via MessageAPI. 
- Some minor bug found in current main branch:
  - $CFG undeclared in scan_file.php: remove and use moodle_url for building urls.
  - Weird reference to $job variable in message formatting. It was changed by $queue.
  - Typo in get_record instead of get_records in extract_files.php adhoc task. (Maybe related to #307)
 
Best regards
