### PR TITLE
Bad state in image processing queue

### DIFF
--- a/lang/en/offlinequiz.php
+++ b/lang/en/offlinequiz.php
@@ -137,6 +137,7 @@ $string['correctionforms'] = 'Correction forms';
 $string['correctionoptionsheading'] = 'Correction options';
 $string['correctupdated'] = 'Updated correction form for group {$a}.';
 $string['couldnotgrab'] = 'Could not grab image {$a}';
+$string['couldnotextractpages'] = 'Error while extracting pages from the uploaded files.';
 $string['couldnotinsertjobs'] = 'Error with the database while extracting pages';
 $string['couldnotregister'] = 'Could not register user {$a}';
 $string['couldnotextracttiff'] = 'Error while converting tiff to single images. Please try a smaller document or contact your local administrator.';

--- a/report/correct/classes/report.php
+++ b/report/correct/classes/report.php
@@ -346,7 +346,7 @@ class report extends default_report {
                 } else if($this->queuehaserrors($queue)) {
                     $element['queuestatuserror'] = true;
                     if($queue->error) {
-                        $element['queueerror'] = get_string($queue->error,'mod_offlinequiz');
+                        $element['queueerror'] = get_string($queue->error,'offlinequiz');
                     }
                 } else if(!$queue->timefinish) {
                     $element['queuestatusprocessing'] = true;

--- a/report/rimport/classes/task/adhoc/extract_files.php
+++ b/report/rimport/classes/task/adhoc/extract_files.php
@@ -124,7 +124,7 @@ class extract_files extends \core\task\adhoc_task {
                 $task->set_next_run_time(time());
                 \core\task\manager::queue_adhoc_task($task, true);
             }
-        } finally {
+        } catch (\exception $e) {
             // Just in case if there is an error and it's still processing write that into the queue.
             if($queue->status == 'processing') {
                 $queue->status = 'error';


### PR DESCRIPTION
A mistake in try-catch statement made that every image processing were marked as error.

Steps:
1) submit a JPG.
2) exec cron jobs.
3) Image is converted to B&W normally by extract_files task.
3) 'finally' clause marks the queue as errored. But it's not.

Expected: Only when a real error triggered. Hence, should be catch instead of finally.

In addtition, error string was not defined in lang file.