### PR TITLE
Fix black images extraction.

### DIFF
--- a/report/rimport/classes/task/adhoc/extract_files.php
+++ b/report/rimport/classes/task/adhoc/extract_files.php
@@ -168,7 +168,7 @@ class extract_files extends \core\task\adhoc_task {
     }
 
     private function convert_black_white($file, $threshold) {
-        $command = "convert " . escapeshellarg(realpath($file)) . " -threshold $threshold% " .  escapeshellarg(realpath($file));
+        $command = "convert " . escapeshellarg(realpath($file)) . " -colorspace gray -threshold $threshold% " .  escapeshellarg(realpath($file));
         popen($command, 'r');
     }
     


### PR DESCRIPTION
As noted in #307 there are images that generates fully black images in "convert_black_white()" process.

I've traced the problem to the colorspace of JPEG profiles: When the colorspace in CMYK the filter "-threshold" fails to calculate the luminance of the image.
According to Imagemagick documentation: https://www.imagemagick.org/script/color-thresholding.php

>  Thresholding, by default, take place in the sRGB colorspace. Use the -colorspace to perform the thresholding in an alternative colorspaces (currently limited to sRGB, Gray, HSV, HSL, HCL, HSB, and HSW).

I decided to transform first to grayscale, then threshold the image. It should be robust for all formats of images.