### PR TITLE
improve controls on the task of deleting temporary files

### DIFF
--- a/classes/task/temporary_file_deletion_task.php
+++ b/classes/task/temporary_file_deletion_task.php
@@ -71,7 +71,7 @@ class temporary_file_deletion_task extends \core\task\scheduled_task {
                     }
                 }
             }
-            if (empty($dirname)) {
+            if (empty($dirname) || $dirname === '.') {
                 $dirname = "$CFG->dataroot/offlinequiz/import/$jobid/";
             }
             if (is_dir($dirname)) {


### PR DESCRIPTION
*Our context : Moodle 5.0 / mod_offlinequiz v5.0.1 / PHP 8.2*

Since September, we have lost several times the contents of our `moodle/admin/cli` directory.

Each time the problem occurred at 4:22 a.m. So, we think it's caused by `mod_offlinequiz\task\temporary_file_deletion_task`.

In our logs, we have the following message : `Removing dir .`

Currently, we have the following filename in `offlinequiz_queue_data table` : `xaaa.tif`

When we use this filename in `pathinfo()` function, `dirname` index has the value of `.`.

```
$ php -r 'var_dump(pathinfo("xaaa.tif"));'
Command line code:1:
array(4) {
  'dirname' =>
  string(1) "."
  'basename' =>
  string(8) "xaaa.tif"
  'extension' =>
  string(3) "tif"
  'filename' =>
  string(4) "xaaa"
}
```
In addition to checking that the `$dirname` variable is not empty, we also suggest to check that `$dirname` variable is not equal to `.`.

Regards,
